### PR TITLE
Changed layered console to use .Position

### DIFF
--- a/SadConsole.Core/Consoles/LayeredConsole.cs
+++ b/SadConsole.Core/Consoles/LayeredConsole.cs
@@ -86,6 +86,11 @@ namespace SadConsole.Consoles
             SetActiveLayer(0);
         }
 
+        protected override void OnPositionChanged(Point oldLocation)
+        {
+            SyncLayers();
+        }
+
         public virtual void SyncLayers()
         {
             if (_layers != null)
@@ -132,18 +137,7 @@ namespace SadConsole.Consoles
 
             ResetViewArea();
         }
-
-        /// <summary>
-        /// Moves all layers to be at the specified position.
-        /// </summary>
-        /// <param name="position">The position of all layers.</param>
-        public void Move(Point position)
-        {
-            this.Position = position;
-
-            SyncLayers();
-        }
-
+        
         public override void Update()
         {
             for (int i = 0; i < _layers.Count; i++)


### PR DESCRIPTION
Changed layered console to use .Position (like it should have originally) instead of .Move to move a console.

Fixes bug #17 

Tested code on StarterProject but didn't include that code.