### PR TITLE
Fixes for core and controls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,15 @@
 ﻿>**NOTE**
 This change log was more relevant when I wasn't using GitHub. Now it only lists major releases and updates to NuGet. The source code iterates much faster and can be checked through the commit history.
 
+## 09/11/206
+
+### Core
+- Fixed possible recursive bug with mouse handling when calling ProcessMouse on console B while in ProcessMouse on console A.
+
+### Controls
+- Fixed released (previously captured) control not giving back Engine.ActiveConsole.
+- Scroll bar now hides slider position when IsEnabled = False.
+
 ## 09/08/2016
 Versions are no longer the same across all libraries.
 

--- a/src/Projects.MonoGameDX/SadConsole.Controls/Properties/AssemblyInfo.cs
+++ b/src/Projects.MonoGameDX/SadConsole.Controls/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.3.0")]
-[assembly: AssemblyFileVersion("3.0.3.0")]
+[assembly: AssemblyVersion("3.0.4.0")]
+[assembly: AssemblyFileVersion("3.0.4.0")]

--- a/src/Projects.MonoGameDX/SadConsole.Controls/SadConsole.Controls.Windows.nuspec
+++ b/src/Projects.MonoGameDX/SadConsole.Controls/SadConsole.Controls.Windows.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SadConsole.Controls</id>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>Thraka</owners>
@@ -12,8 +12,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>(Uses MonoGame DirectX) $description$</description>
     <releaseNotes>
-Fixed bug with button control rendering.
-Fixed DLL version.
+Fixed released (previously captured) control not giving back Engine.ActiveConsole.
+Scroll bar now hides slider position when IsEnabled = False.
     </releaseNotes>
     <copyright>Copyright 2016 Steve De George JR</copyright>
     <tags>monogame roguelike cli xna game development console ansi ascii</tags>

--- a/src/Projects.MonoGameDX/SadConsole.Core/Properties/AssemblyInfo.cs
+++ b/src/Projects.MonoGameDX/SadConsole.Core/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyVersion("5.0.1.0")]
+[assembly: AssemblyFileVersion("5.0.1.0")]

--- a/src/Projects.MonoGameDX/SadConsole.Core/SadConsole.Core.Windows.nuspec
+++ b/src/Projects.MonoGameDX/SadConsole.Core/SadConsole.Core.Windows.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SadConsole.Core</id>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>Thraka</owners>
@@ -12,9 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>(Uses MonoGame DirectX) $description$</description>
     <releaseNotes>
-Updated all serialization for base types.
-TextSurfaceView now a proper type that doesn't inherit from TextSurface for its function.
-Cursor supports using the ColoredString parser system.
+Fixed possible recursive bug with mouse handling when calling ProcessMouse on console B while in ProcessMouse on console A.
     </releaseNotes>
     <copyright>Copyright 2016 Steve De George JR</copyright>
     <tags>monogame roguelike cli xna game development console ansi ascii</tags>

--- a/src/Projects.MonoGameGL/SadConsole.Controls/Properties/AssemblyInfo.cs
+++ b/src/Projects.MonoGameGL/SadConsole.Controls/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.3.0")]
-[assembly: AssemblyFileVersion("3.0.3.0")]
+[assembly: AssemblyVersion("3.0.4.0")]
+[assembly: AssemblyFileVersion("3.0.4.0")]

--- a/src/Projects.MonoGameGL/SadConsole.Controls/SadConsole.Controls.OpenGL.nuspec
+++ b/src/Projects.MonoGameGL/SadConsole.Controls/SadConsole.Controls.OpenGL.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SadConsole.Controls.MonoGameGL</id>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>Thraka</owners>
@@ -12,8 +12,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>(Uses MonoGame GL) $description$</description>
     <releaseNotes>
-Fixed bug with button control rendering.
-Fixed DLL version.
+Fixed released (previously captured) control not giving back Engine.ActiveConsole.
+Scroll bar now hides slider position when IsEnabled = False.
     </releaseNotes>
     <copyright>Copyright 2016 Steve De George JR</copyright>
     <tags>monogame roguelike cli xna game development console ansi ascii</tags>

--- a/src/Projects.MonoGameGL/SadConsole.Core/Properties/AssemblyInfo.cs
+++ b/src/Projects.MonoGameGL/SadConsole.Core/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyVersion("5.0.1.0")]
+[assembly: AssemblyFileVersion("5.0.1.0")]

--- a/src/Projects.MonoGameGL/SadConsole.Core/SadConsole.Core.OpenGL.nuspec
+++ b/src/Projects.MonoGameGL/SadConsole.Core/SadConsole.Core.OpenGL.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SadConsole.Core.MonoGameGL</id>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>Thraka</owners>
@@ -12,9 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>(Uses MonoGame GL) $description$</description>
     <releaseNotes>
-Updated all serialization for base types.
-TextSurfaceView now a proper type that doesn't inherit from TextSurface for its function.
-Cursor supports using the ColoredString parser system.
+Fixed possible recursive bug with mouse handling when calling ProcessMouse on console B while in ProcessMouse on console A.
     </releaseNotes>
     <copyright>Copyright 2016 Steve De George JR</copyright>
     <tags>monogame roguelike cli xna game development console ansi ascii</tags>

--- a/src/Projects.SFML/SadConsole.Controls/Properties/AssemblyInfo.cs
+++ b/src/Projects.SFML/SadConsole.Controls/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("3.0.3.0")]
-[assembly: AssemblyFileVersion("3.0.3.0")]
+[assembly: AssemblyVersion("3.0.4.0")]
+[assembly: AssemblyFileVersion("3.0.4.0")]

--- a/src/Projects.SFML/SadConsole.Controls/SadConsole.Controls.SFML.nuspec
+++ b/src/Projects.SFML/SadConsole.Controls/SadConsole.Controls.SFML.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SadConsole.Controls.SFML</id>
-    <version>3.0.3</version>
+    <version>3.0.4</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>Thraka</owners>
@@ -12,8 +12,8 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
-Fixed bug with button control rendering.
-Fixed DLL version.
+Fixed released (previously captured) control not giving back Engine.ActiveConsole.
+Scroll bar now hides slider position when IsEnabled = False.
     </releaseNotes>
     <copyright>Copyright 2016 Steve De George JR</copyright>
     <tags>sfml sadconsole roguelike cli game development console ansi ascii</tags>

--- a/src/Projects.SFML/SadConsole.Core/Properties/AssemblyInfo.cs
+++ b/src/Projects.SFML/SadConsole.Core/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("5.0.0.0")]
-[assembly: AssemblyFileVersion("5.0.0.0")]
+[assembly: AssemblyVersion("5.0.1.0")]
+[assembly: AssemblyFileVersion("5.0.1.0")]

--- a/src/Projects.SFML/SadConsole.Core/SadConsole.Core.SFML.nuspec
+++ b/src/Projects.SFML/SadConsole.Core/SadConsole.Core.SFML.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SadConsole.Core.SFML</id>
-    <version>5.0.0</version>
+    <version>5.0.1</version>
     <title>$title$</title>
     <authors>$author$</authors>
     <owners>Thraka</owners>
@@ -12,9 +12,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>$description$</description>
     <releaseNotes>
-Updated all serialization for base types.
-TextSurfaceView now a proper type that doesn't inherit from TextSurface for its function.
-Cursor supports using the ColoredString parser system.
+Fixed possible recursive bug with mouse handling when calling ProcessMouse on console B while in ProcessMouse on console A.
     </releaseNotes>
     <copyright>Copyright 2016 Steve De George JR</copyright>
     <tags>sfml monogame roguelike cli game development console ansi ascii</tags>

--- a/src/SadConsole.Controls/Consoles/ControlsConsole.cs
+++ b/src/SadConsole.Controls/Consoles/ControlsConsole.cs
@@ -31,6 +31,7 @@ namespace SadConsole.Consoles
         [DataMember]
         private ControlBase _capturedControl;
         private bool _exlusiveBeforeCapture;
+        private IConsole _activeBeforeCapture;
 
         private SadConsole.Themes.ControlsConsoleTheme _theme;
 
@@ -496,6 +497,7 @@ namespace SadConsole.Consoles
         /// <param name="control">The control to capture</param>
         public void CaptureControl(ControlBase control)
         {
+            _activeBeforeCapture = Engine.ActiveConsole;
             Engine.ActiveConsole = this;
             _exlusiveBeforeCapture = ExclusiveFocus;
             ExclusiveFocus = true;
@@ -507,6 +509,7 @@ namespace SadConsole.Consoles
         /// </summary>
         public void ReleaseControl()
         {
+            Engine.ActiveConsole = _activeBeforeCapture;
             ExclusiveFocus = _exlusiveBeforeCapture;
             _capturedControl = null;
         }

--- a/src/SadConsole.Controls/Controls/ScrollBar.cs
+++ b/src/SadConsole.Controls/Controls/ScrollBar.cs
@@ -269,8 +269,11 @@ namespace SadConsole.Controls
 
                 if (_value >= _minValue && _value <= _maxValue && _minValue != _maxValue)
                 {
-                    this.SetCellAppearance(1 + _currentSliderPosition, 0, Theme.Slider.Normal);
-                    this.SetGlyph(1 + _currentSliderPosition, 0, _sliderCharacter);
+                    if (IsEnabled)
+                    {
+                        this.SetCellAppearance(1 + _currentSliderPosition, 0, Theme.Slider.Normal);
+                        this.SetGlyph(1 + _currentSliderPosition, 0, _sliderCharacter);
+                    }
                 }
             }
             else
@@ -289,8 +292,11 @@ namespace SadConsole.Controls
 
                 if (_value >= _minValue && _value <= _maxValue && _minValue != _maxValue)
                 {
-                    this.SetCellAppearance(0, 1 + _currentSliderPosition, Theme.Slider.Normal);
-                    this.SetGlyph(0, 1 + _currentSliderPosition, _sliderCharacter);
+                    if (IsEnabled)
+                    {
+                        this.SetCellAppearance(0, 1 + _currentSliderPosition, Theme.Slider.Normal);
+                        this.SetGlyph(0, 1 + _currentSliderPosition, _sliderCharacter);
+                    }
                 }
 
             }

--- a/src/SadConsole.Core/Input/MouseInfo.cs
+++ b/src/SadConsole.Core/Input/MouseInfo.cs
@@ -187,10 +187,12 @@ namespace SadConsole.Input
                     if (Engine.LastMouseConsole != null)
                     {
                         var info = this.Clone();
-                        Engine.LastMouseConsole.ProcessMouse(info);
+                        var oldConsole = Engine.LastMouseConsole;
+                        Engine.LastMouseConsole = data;
+                        oldConsole.ProcessMouse(info);
                     }
-
-                    Engine.LastMouseConsole = data;
+                    else
+                        Engine.LastMouseConsole = data;
                 }
             }
         }


### PR DESCRIPTION
## Core
- Fixed possible recursive bug with mouse handling when calling ProcessMouse on console B while in ProcessMouse on console A.

## Controls
- Fixed released (previously captured) control not giving back Engine.ActiveConsole.
- Scroll bar now hides slider position when IsEnabled = False.