### PR TITLE
Fixing ArgumentOutOfRange exception issue #100

### DIFF
--- a/src/SadConsole.Shared/Controls/InputBox.cs
+++ b/src/SadConsole.Shared/Controls/InputBox.cs
@@ -518,7 +518,6 @@ namespace SadConsole.Controls
                 base.OnLeftMouseClicked(state);
 
                 DisableKeyboard = false;
-                _editingText = Text;
 
                 if (!IsFocused)
                     Parent.FocusedControl = this;


### PR DESCRIPTION
So, I was able to get by this issue by removing what seemed like `Text` variable. One which always returned `""` on every left-click.

It seems to work fine now. As per #100's issue... those steps can now be resolved.

Let me know if I missed something but more than likely, that line I deleted was probably important...? First C# PR here... (. _.)