### PR TITLE
Merge release 7.1.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,12 @@
-﻿## 09/08/2018 V7.0.3 / 7.0.4
+﻿## 10/18/2018 V7.1.0
+
+- Moved SurfaceBase.GetIndexFromPoint to Helpers class.
+- Fixed bug in EntityManager that did not remove entity/hotspot/zone parents when the EntityManager's parent was cleared.
+- EntityManager does not support .Clear calls on collections. Instead, use the RemoveAll extension method.
+- An extension method was added: SurfaceBase.CenterViewPortOnPoint
+- An extension method was added: Rectangle.CenterOnPoint
+
+## 09/08/2018 V7.0.3 / 7.0.4
 
 - Fixed bug with textbox displaying two carets.
 - If TextBox was first control in console, rendering was wrong.

--- a/nuget/SadConsole.nuspec
+++ b/nuget/SadConsole.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SadConsole</id>
-    <version>7.0.4</version>
+    <version>7.1.0</version>
     <title>SadConsole for MonoGame</title>
     <authors>SadLogic</authors>
     <owners>Thraka</owners>
@@ -11,38 +11,11 @@
     <iconUrl>https://raw.githubusercontent.com/Thraka/SadConsole/d110fc4a0dfdaa25496c973518ea6a14a563e191/images/oD8yyro5.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A MonoGame library that emulates old-school console and command prompt style graphics. Use the SadConsole.Starter package for new projects.</description>
-    <releaseNotes>7.0.0 [BREAKING CHANGES]
-- New SurfaceBase class which all Surface's inherit from.
-- SurfaceBase has an IRenderer on it directly now.
-- SurfaceEditor has been removed and is now implemented on SurfaceBase directly.
-- Console no longer combines Renderer and TextSurface for drawing.
-- Draw(SpriteBatch batch, Point position, Point size, Font font) has been removed.
-- Cell/CellState have a Decorators list which are used to add extra glyph draws to individual cells.
-- CellDecorator class added that has a color, glyph, and mirror setting.
-- SadConsole.Serialization uses Newtonsoft.Json instead of the default .NET classes.
-- SadConsole.Serialization supports GZIP compression now.
-- Settings.SerializationIsCompressed can be set to true to set all internal save/load to use compression.
-- Control themes completely rewritten. Themes control all drawing for a control now.
-- Windows/ControlsConsole use a theme for drawing.
-- InputBox renamed TextBox.
-- Removed GameHelpers namespace. Types moved to root namespace.
-- GameObject renamed to Entity.
-- Surface.RenderArea changed to Surface.ViewPort
-- Readded Zone and HotSpot types.
-- Removed random level generation.
-- Added Entities.EntityManager which helps control entity visibility and offsets based on a parent console. Also handles zones/hotspots.
-
-7.0.2
-
-- Fixed render bug with Entity/Animation if no parent was attached.
-- Fixed ColoredString + operator.
-- SadConsole IBM Extended font embedded in library now.
-
-7.0.3 / 7.0.4
-
-- TextBox had a double caret in some cases.
-- If TextBox was first control in console, rendering was wrong.
-- Added int overload for Helpers.*Flag related methods.
+    <releaseNotes>- Moved SurfaceBase.GetIndexFromPoint to Helpers class.
+- Fixed bug in EntityManager that did not remove entity/hotspot/zone parents when the EntityManager's parent was cleared.
+- EntityManager does not support .Clear calls on collections. Instead, use the RemoveAll extension method.
+- An extension method was added: SurfaceBase.CenterViewPortOnPoint
+- An extension method was added: Rectangle.CenterOnPoint
     </releaseNotes>
     <copyright>Copyright 2018 Steve De George JR</copyright>
     <tags>monogame roguelike cli xna game development console ansi ascii</tags>

--- a/nuget/SadConsoleFNA.nuspec
+++ b/nuget/SadConsoleFNA.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>SadConsole.FNA</id>
-    <version>7.0.4</version>
+    <version>7.1.0</version>
     <title>SadConsole for FNA</title>
     <authors>SadLogic</authors>
     <owners>Thraka</owners>
@@ -11,41 +11,14 @@
     <iconUrl>https://raw.githubusercontent.com/Thraka/SadConsole/d110fc4a0dfdaa25496c973518ea6a14a563e191/images/oD8yyro5.png</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>An FNA library that emulates old-school console and command prompt style graphics. Use the SadConsole.Starter package for new projects.</description>
-    <releaseNotes>[BREAKING CHANGES]
-- New SurfaceBase class which all Surface's inherit from.
-- SurfaceBase has an IRenderer on it directly now.
-- SurfaceEditor has been removed and is now implemented on SurfaceBase directly.
-- Console no longer combines Renderer and TextSurface for drawing.
-- Draw(SpriteBatch batch, Point position, Point size, Font font) has been removed.
-- Cell/CellState have a Decorators list which are used to add extra glyph draws to individual cells.
-- CellDecorator class added that has a color, glyph, and mirror setting.
-- SadConsole.Serialization uses Newtonsoft.Json instead of the default .NET classes.
-- SadConsole.Serialization supports GZIP compression now.
-- Settings.SerializationIsCompressed can be set to true to set all internal save/load to use compression.
-- Control themes completely rewritten. Themes control all drawing for a control now.
-- Windows/ControlsConsole use a theme for drawing.
-- InputBox renamed TextBox.
-- Removed GameHelpers namespace. Types moved to root namespace.
-- GameObject renamed to Entity.
-- Surface.RenderArea changed to Surface.ViewPort
-- Readded Zone and HotSpot types.
-- Removed random level generation.
-- Added Entities.EntityManager which helps control entity visibility and offsets based on a parent console. Also handles zones/hotspots.
-
-7.0.2
-
-- Fixed render bug with Entity/Animation if no parent was attached.
-- Fixed ColoredString + operator.
-- SadConsole IBM Extended font embedded in library now.
-
-7.0.3 / 7.0.4
-
-- TextBox had a double caret in some cases.
-- If TextBox was first control in console, rendering was wrong.
-- Added int overload for Helpers.*Flag related methods.
+    <releaseNotes>- Moved SurfaceBase.GetIndexFromPoint to Helpers class.
+- Fixed bug in EntityManager that did not remove entity/hotspot/zone parents when the EntityManager's parent was cleared.
+- EntityManager does not support .Clear calls on collections. Instead, use the RemoveAll extension method.
+- An extension method was added: SurfaceBase.CenterViewPortOnPoint
+- An extension method was added: Rectangle.CenterOnPoint
     </releaseNotes>
     <copyright>Copyright 2018 Steve De George JR</copyright>
-    <tags>monogame roguelike cli xna game development console ansi ascii</tags>
+    <tags>fna roguelike cli xna game development console ansi ascii</tags>
     <dependencies>
       <dependency id="Newtonsoft.Json" version="11.0.2" />
     </dependencies>

--- a/src/SadConsole.Shared/Entities/EntityManager.cs
+++ b/src/SadConsole.Shared/Entities/EntityManager.cs
@@ -43,7 +43,6 @@ namespace SadConsole.Entities
             Entities.CollectionChanged += EntitiesOnCollectionChanged;
             Zones.CollectionChanged += EntitiesOnCollectionChanged;
             Hotspots.CollectionChanged += EntitiesOnCollectionChanged;
-
         }
 
         private void EntitiesOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
@@ -68,8 +67,7 @@ namespace SadConsole.Entities
                 case NotifyCollectionChangedAction.Move:
                     break;
                 case NotifyCollectionChangedAction.Reset:
-                    
-                    break;
+                    throw new NotSupportedException("Calling Clear in this object is not supported. Please use the RemoveAll extension method.");
                 default:
                     throw new ArgumentOutOfRangeException();
             }
@@ -83,22 +81,19 @@ namespace SadConsole.Entities
             _surfaceParent = newParent as SurfaceBase;
             IsPaused = _surfaceParent == null;
 
-            if (_surfaceParent != null)
-            {
-                foreach (var zone in Zones)
-                    if (zone.Parent != _surfaceParent)
-                        zone.Parent = _surfaceParent;
+            foreach (var zone in Zones)
+                if (zone.Parent != _surfaceParent)
+                    zone.Parent = _surfaceParent;
 
-                foreach (var spot in Hotspots)
-                    if (spot.Parent != _surfaceParent)
-                        spot.Parent = _surfaceParent;
+            foreach (var spot in Hotspots)
+                if (spot.Parent != _surfaceParent)
+                    spot.Parent = _surfaceParent;
 
-                foreach (var entity in Entities)
-                    if (entity.Parent != _surfaceParent)
-                        entity.Parent = _surfaceParent;
+            foreach (var entity in Entities)
+                if (entity.Parent != _surfaceParent)
+                    entity.Parent = _surfaceParent;
 
-                Sync();
-            }
+            Sync();
         }
 
         /// <inheritdoc />

--- a/src/SadConsole.Shared/Extensions/IListExtensions.cs
+++ b/src/SadConsole.Shared/Extensions/IListExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Text;
+using System.Linq;
+
+namespace SadConsole
+{
+    public static class IListExtensions
+    {
+        /// <summary>
+        /// Removes each item from a list one-by-one.
+        /// </summary>
+        /// <param name="list">The list collection to remove from.</param>
+        public static void RemoveAll(this IList list)
+        {
+            while (list.Count > 0)
+            {
+                list.RemoveAt(list.Count - 1);
+            }
+        }
+    }
+}

--- a/src/SadConsole.Shared/Extensions/PointExtensions.cs
+++ b/src/SadConsole.Shared/Extensions/PointExtensions.cs
@@ -56,10 +56,7 @@ namespace Microsoft.Xna.Framework
         /// <param name="point">The position.</param>
         /// <param name="rowWidth">How many columns in a row.</param>
         /// <returns></returns>
-        public static int ToIndex(this Point point, int rowWidth)
-        {
-            return point.Y * rowWidth + point.X;
-        }
+        public static int ToIndex(this Point point, int rowWidth) => Helpers.GetIndexFromPoint(point.X, point.Y, rowWidth);
 
         /// <summary>
         /// Gets the cell coordinates of the <paramref name="targetFont"/> based on a cell in the <paramref name="sourceFont"/>.

--- a/src/SadConsole.Shared/Extensions/RectangleExtensions.cs
+++ b/src/SadConsole.Shared/Extensions/RectangleExtensions.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.Xna.Framework;
+using SadConsole.Surfaces;
+
+namespace SadConsole
+{
+    public static class RectangleExtensions
+    {
+        public static void CenterViewPortOnPoint(this SurfaceBase surface, Point target)
+        {
+            surface.ViewPort = surface.ViewPort.CenterOnPoint(target, surface.Width, surface.Height);
+        }
+
+        public static Rectangle CenterOnPoint(this Rectangle rect, Point target, int maxWidth, int maxHeight)
+        {
+            var newRect = rect;
+            newRect.Location = new Point(target.X - newRect.Width / 2, target.Y - newRect.Height / 2);
+
+            if (newRect.Right > maxWidth)
+                newRect.X -= newRect.Right - maxWidth;
+            else if (newRect.Left < 0)
+                newRect.X = 0;
+
+            if (newRect.Bottom > maxHeight)
+                newRect.Y -= newRect.Bottom - maxHeight;
+            else if (newRect.Top < 0)
+                newRect.Y = 0;
+
+            return newRect;
+        }
+    }
+}

--- a/src/SadConsole.Shared/Helpers.cs
+++ b/src/SadConsole.Shared/Helpers.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
+using Microsoft.Xna.Framework;
 using SadConsole.Controls;
 
 namespace SadConsole
@@ -42,6 +43,31 @@ namespace SadConsole
         public static int UnsetFlag(int state, int flag)
         {
             return state & ~flag;
+        }
+
+        /// <summary>
+        /// Gets the x,y of an index on the surface.
+        /// </summary>
+        /// <param name="index">The index to get.</param>
+        /// <param name="width">Width that includes the index.</param>
+        /// <returns>The x,y as a <see cref="Point"/>.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Point GetPointFromIndex(int index, int width)
+        {
+            return new Point(index % width, index / width);
+        }
+
+        /// <summary>
+        /// Gets the index of a location on the surface by coordinate.
+        /// </summary>
+        /// <param name="x">The x of the location.</param>
+        /// <param name="y">The y of the location.</param>
+        /// <param name="width">Width that includes the point.</param>
+        /// <returns>The cell index.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static int GetIndexFromPoint(int x, int y, int width)
+        {
+            return y * width + x;
         }
     }
 }

--- a/src/SadConsole.Shared/SadConsole.Shared.projitems
+++ b/src/SadConsole.Shared/SadConsole.Shared.projitems
@@ -66,7 +66,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Entities\EntityManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ColorExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ColorGradient.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\IListExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\PointExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensions\RectangleExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\StringExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\SurfaceExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\TextureExtensions.cs" />

--- a/src/SadConsole.Shared/SadConsole.csproj
+++ b/src/SadConsole.Shared/SadConsole.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>7.2</LangVersion>
     <AssemblyName>SadConsole</AssemblyName>
-    <Version>7.0.4</Version>
+    <Version>7.1.0</Version>
     <Authors>Thraka</Authors>
     <Company>SadLogic</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
@@ -13,41 +13,12 @@
     <Copyright>Copyright © 2018 Steve De George JR (Thraka)</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>SadConsole.Standard</PackageId>
-    <PackageReleaseNotes>First release of standard 2.0 library.
-
-7.0.0 [BREAKING CHANGES]
-- New SurfaceBase class which all Surface's inherit from.
-- SurfaceBase has an IRenderer on it directly now.
-- SurfaceEditor has been removed and is now implemented on SurfaceBase directly.
-- Console no longer combines Renderer and TextSurface for drawing.
-- Draw(SpriteBatch batch, Point position, Point size, Font font) has been removed.
-- Cell/CellState have a Decorators list which are used to add extra glyph draws to individual cells.
-- CellDecorator class added that has a color, glyph, and mirror setting.
-- SadConsole.Serialization uses Newtonsoft.Json instead of the default .NET classes.
-- SadConsole.Serialization supports GZIP compression now.
-- Settings.SerializationIsCompressed can be set to true to set all internal save/load to use compression.
-- Control themes completely rewritten. Themes control all drawing for a control now.
-- Windows/ControlsConsole use a theme for drawing.
-- InputBox renamed TextBox.
-- Removed GameHelpers namespace. Types moved to root namespace.
-- GameObject renamed to Entity.
-- Surface.RenderArea changed to Surface.ViewPort
-- Readded Zone and HotSpot types.
-- Removed random level generation.
-- Added Entities.EntityManager which helps control entity visibility and offsets based on a parent console. Also handles zones/hotspots.
-
-7.0.2
-
-- Fixed render bug with Entity/Animation if no parent was attached.
-- Fixed ColoredString + operator.
-- SadConsole IBM Extended font embedded in library now.
-
-7.0.3 / 7.0.4
-
-- TextBox had a double caret in some cases.
-- If TextBox was first control in console, rendering was wrong.
-- Added int overload for Helpers.*Flag related methods.</PackageReleaseNotes>
-    <AssemblyVersion>7.0.4.0</AssemblyVersion>
+    <PackageReleaseNotes>- Moved SurfaceBase.GetIndexFromPoint to Helpers class.
+- Fixed bug in EntityManager that did not remove entity/hotspot/zone parents when the EntityManager's parent was cleared.
+- EntityManager does not support .Clear calls on collections. Instead, use the RemoveAll extension method.
+- An extension method was added: SurfaceBase.CenterViewPortOnPoint
+- An extension method was added: Rectangle.CenterOnPoint</PackageReleaseNotes>
+    <AssemblyVersion>7.1.0.0</AssemblyVersion>
     <PackageIconUrl>https://raw.githubusercontent.com/Thraka/SadConsole/d110fc4a0dfdaa25496c973518ea6a14a563e191/images/oD8yyro5.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Thraka/SadConsole</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/src/SadConsole.Shared/SadConsole.xml
+++ b/src/SadConsole.Shared/SadConsole.xml
@@ -2628,6 +2628,12 @@
         <member name="M:SadConsole.Entities.Zone.Draw(System.TimeSpan)">
             <inheritdoc />
         </member>
+        <member name="M:SadConsole.IListExtensions.RemoveAll(System.Collections.IList)">
+            <summary>
+            Removes each item from a list one-by-one.
+            </summary>
+            <param name="list">The list collection to remove from.</param>
+        </member>
         <member name="T:SadConsole.Font">
             <summary>
             Represents a specific font size from a <see cref="T:SadConsole.FontMaster"/>.
@@ -3037,6 +3043,23 @@
             <summary>
             Raised when the window is resized and the render area has been calculated.
             </summary>
+        </member>
+        <member name="M:SadConsole.Helpers.GetPointFromIndex(System.Int32,System.Int32)">
+            <summary>
+            Gets the x,y of an index on the surface.
+            </summary>
+            <param name="index">The index to get.</param>
+            <param name="width">Width that includes the index.</param>
+            <returns>The x,y as a <see cref="T:Microsoft.Xna.Framework.Point"/>.</returns>
+        </member>
+        <member name="M:SadConsole.Helpers.GetIndexFromPoint(System.Int32,System.Int32,System.Int32)">
+            <summary>
+            Gets the index of a location on the surface by coordinate.
+            </summary>
+            <param name="x">The x of the location.</param>
+            <param name="y">The y of the location.</param>
+            <param name="width">Width that includes the point.</param>
+            <returns>The cell index.</returns>
         </member>
         <member name="T:SadConsole.IConsole">
             <summary>
@@ -5609,14 +5632,6 @@
             <summary>
             Array index enum for line glyphs.
             </summary>
-        </member>
-        <member name="M:SadConsole.Surfaces.SurfaceBase.GetIndexFromPoint(System.Int32,System.Int32,System.Int32)">
-            <summary>
-            Gets the index of a location on the surface by coordinate.
-            </summary>
-            <param name="x">The x of the location.</param>
-            <param name="y">The y of the location.</param>
-            <returns>The cell index.</returns>
         </member>
         <member name="T:SadConsole.Themes.ButtonTheme">
             <summary>

--- a/src/SadConsole.Shared/Surfaces/SurfaceBase.Editor.Static.cs
+++ b/src/SadConsole.Shared/Surfaces/SurfaceBase.Editor.Static.cs
@@ -70,17 +70,5 @@ namespace SadConsole.Surfaces
             BottomMiddleToTop,
 #pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
         }
-
-        /// <summary>
-        /// Gets the index of a location on the surface by coordinate.
-        /// </summary>
-        /// <param name="x">The x of the location.</param>
-        /// <param name="y">The y of the location.</param>
-        /// <returns>The cell index.</returns>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static int GetIndexFromPoint(int x, int y, int width)
-        {
-            return y * width + x;
-        }
     }
 }

--- a/src/SadConsole.Universal/Properties/AssemblyInfo.cs
+++ b/src/SadConsole.Universal/Properties/AssemblyInfo.cs
@@ -24,6 +24,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.4.0")]
-[assembly: AssemblyFileVersion("7.0.4.0")]
+[assembly: AssemblyVersion("7.1.0.0")]
+[assembly: AssemblyFileVersion("7.1.0.0")]
 [assembly: ComVisible(false)]

--- a/src/SadConsole/Properties/AssemblyInfo.cs
+++ b/src/SadConsole/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.4")]
-[assembly: AssemblyFileVersion("7.0.4")]
+[assembly: AssemblyVersion("7.1.0")]
+[assembly: AssemblyFileVersion("7.1.0")]

--- a/src/SadConsoleFNA/Properties/AssemblyInfo.cs
+++ b/src/SadConsoleFNA/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("7.0.4")]
-[assembly: AssemblyFileVersion("7.0.4")]
+[assembly: AssemblyVersion("7.1.0")]
+[assembly: AssemblyFileVersion("7.1.0")]


### PR DESCRIPTION
- Moved SurfaceBase.GetIndexFromPoint to Helpers class.
- Fixed bug in EntityManager that did not remove entity/hotspot/zone parents when the EntityManager's parent was cleared.
- EntityManager does not support .Clear calls on collections. Instead, use the RemoveAll extension method.
- An extension method was added: SurfaceBase.CenterViewPortOnPoint
- An extension method was added: Rectangle.CenterOnPoint