### PR TITLE
Fix a few Entity.cs documentation typos

### DIFF
--- a/src/SadConsole/Entities/Entity.cs
+++ b/src/SadConsole/Entities/Entity.cs
@@ -120,9 +120,9 @@ namespace SadConsole.Entities
         }
 
         /// <summary>
-        /// Creates a new Entity with a default animation/
+        /// Creates a new Entity with a default animation.
         /// </summary>
-        /// <param name="animation">The default animation. The animation will have its <see cref="AnimatedConsole.Name"/> property changesd to "default".</param>
+        /// <param name="animation">The default animation. The animation will have its <see cref="AnimatedConsole.Name"/> property changed to "default".</param>
         public Entity(AnimatedConsole animation)
         {
             Font = animation.Font;
@@ -196,7 +196,7 @@ namespace SadConsole.Entities
             public readonly Entity Entity;
 
             /// <summary>
-            /// The positiont the <see cref="Entity"/> moved from.
+            /// The position the <see cref="Entity"/> moved from.
             /// </summary>
             public readonly Point FromPosition;
 


### PR DESCRIPTION
This PR just fixes a few Entity.cs documentation typos that I stumbled across while reading the source code.

By the way, thanks for making SadConsole! I am teaching an intro to programming C# class, and I'm tacking on a few intro to SadConsole lessons to help adventurous students who want to go beyond System.Console for their final projects. For the context of the classroom, SadConsole hits the sweet spot of giving students a powerful environment to get started immediately with their C# knowledge, without needing to spend a week or two learning a new user interface / asset pipeline like in Unity.

(Doh: just realized active development is happening on other branches. Happy to close and resubmit on a different branch if you'd like)