### PR TITLE
Re-scaled ScreenObject Performance Tests

### DIFF
--- a/PerformanceTests/SadConsole.PerformanceTests/ScreenObject.cs
+++ b/PerformanceTests/SadConsole.PerformanceTests/ScreenObject.cs
@@ -47,7 +47,7 @@ namespace SadConsole.PerformanceTests
     /// </summary>
     /// <remarks>
     /// The current tests only test the main-game-loop oriented functions of ScreenObject.  These tests have the following notable characteristics:
-    ///     - The children are all themselves ScreenObject instances, with 0 components and 0 children
+    ///     - The children are all themselves ScreenObject instances, with the specified number of components and 0 children
     ///         - This means that optimizations to the ScreenObject functions recursively cause performance gains when children are processed
     ///     - The components are processed in all 4 elements of the main game loop (Update, Render, ProcessKeyboard, ProcessMouse), but the functions called for these
     ///       events do nothing (blank implementation).
@@ -59,10 +59,10 @@ namespace SadConsole.PerformanceTests
     {
         #region Test Data
 
-        [Params(0, 1, 100, 1000)]
+        [Params(0, 5, 10)]
         public int NumComponents;
 
-        [Params(0, 1, 100, 1000)]
+        [Params(0, 100, 1000)]
         public int NumChildren;
 
         #endregion
@@ -75,12 +75,19 @@ namespace SadConsole.PerformanceTests
         public void GlobalSetup()
         {
             _gameHost = new BasicGameHost();
-            _mainObject = new SadConsole.ScreenObject();
-            for (int i = 0; i < NumComponents; i++)
-                _mainObject.SadComponents.Add(new TestComponent());
 
+            // Create parent object
+            _mainObject = new SadConsole.ScreenObject();
+
+            // Create number of children, each with the specified number of components
             for (int i = 0; i < NumChildren; i++)
-                _mainObject.Children.Add(new SadConsole.ScreenObject());
+            {
+                var child = new SadConsole.ScreenObject();
+                for (int j = 0; j < NumComponents; j++)
+                    child.SadComponents.Add(new TestComponent());
+
+                _mainObject.Children.Add(child);
+            }
 
             _delta = TimeSpan.FromMilliseconds(5);
         }


### PR DESCRIPTION
This PR re-scales the input values for the `ScreenObject` test-cases to reflect a set of cases that should be more realistic (high numbers of children, low numbers of components per child).

It now scales as follows:
- One parent object, with 0 components
    - Parent object has `NumChildren` children (0, 100, and 1000)
    - Each child has `NumComponents` components (0, 5, and 10)