### PR TITLE
9.2.2 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,12 @@ SadConsole uses NuGet for its .NET dependencies:
 
 ## Latest changes
 
-**v9.2.1 (01/04/2022)**
+**v9.2.2 (01/22/2022)**
 
-(v9.2.1 fixes API documentation generation, all other changes are for 9.2.0)
+(v9.2.2 Fix conversion of Mirror to SpriteEffects)\
+(v9.2.1 Fix API documentation generation)
+
+**9.2.0**
 
 ### Breaking changes
 

--- a/SadConsole.Host.MonoGame/Extensions.cs
+++ b/SadConsole.Host.MonoGame/Extensions.cs
@@ -7,19 +7,25 @@ namespace SadConsole.Host.MonoGame
 {
     public static class Extensions
     {
+        /// <summary>
+        /// Converts a <see cref="Mirror"/> type to a MonoGame <see cref="Microsoft.Xna.Framework.Graphics.SpriteEffects"/> type.
+        /// </summary>
+        /// <param name="mirror">The value to convert.</param>
+        /// <returns>The MonoGame equivalent.</returns>
         public static Microsoft.Xna.Framework.Graphics.SpriteEffects ToMonoGame(this Mirror mirror)
         {
-            switch (mirror)
-            {
-                case Mirror.None:
-                    return Microsoft.Xna.Framework.Graphics.SpriteEffects.None;
-                case Mirror.Vertical:
-                    return Microsoft.Xna.Framework.Graphics.SpriteEffects.FlipVertically;
-                case Mirror.Horizontal:
-                    return Microsoft.Xna.Framework.Graphics.SpriteEffects.FlipHorizontally;
-                default:
-                    return Microsoft.Xna.Framework.Graphics.SpriteEffects.None;
-            }
+            Microsoft.Xna.Framework.Graphics.SpriteEffects result = Microsoft.Xna.Framework.Graphics.SpriteEffects.None;
+
+            if (mirror == Mirror.None)
+                return result;
+
+            if ((mirror & Mirror.Vertical) == Mirror.Vertical)
+                result |= Microsoft.Xna.Framework.Graphics.SpriteEffects.FlipVertically;
+
+            if ((mirror & Mirror.Horizontal) == Mirror.Horizontal)
+                result |= Microsoft.Xna.Framework.Graphics.SpriteEffects.FlipHorizontally;
+
+            return result;
         }
     }
 }

--- a/SadConsole.Host.MonoGame/SadConsole.Host.MonoGame.csproj
+++ b/SadConsole.Host.MonoGame/SadConsole.Host.MonoGame.csproj
@@ -4,14 +4,14 @@
     <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <RootNamespace>SadConsole.Host.MonoGame</RootNamespace>
     <DocumentationFile>SadConsole.Host.MonoGame.xml</DocumentationFile>
-    <Version>9.2.1</Version>
+    <Version>9.2.2</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
     <Authors>Thraka</Authors>
     <Company>SadLogic</Company>
     <NeutralLanguage>en-US</NeutralLanguage>
     <AssemblyTitle>SadConsole (.NET Standard)</AssemblyTitle>
     <Description>A graphics hosting library for SadConsole. Targets MonoGame and .NET Standard 2.1.</Description>
-    <Copyright>Copyright © 2020 Steve De George JR (Thraka)</Copyright>
+    <Copyright>Copyright © 2022 Steve De George JR (Thraka)</Copyright>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>SadConsole.Host.MonoGame</PackageId>
     <PackageIcon>nugeticon.png</PackageIcon>
@@ -25,7 +25,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedAllSources>true</EmbedAllSources>
     <PackageTags>monogame;roguelike;cli;xna;game;development;console;ansi;ascii;textmode;sadconsole</PackageTags>
-    <PackageReleaseNotes>Various little fixes. Updates for SadConsole 9.2.1</PackageReleaseNotes>
+    <PackageReleaseNotes>Fix mirror on glyphs.</PackageReleaseNotes>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -34,7 +34,7 @@
   
   <ItemGroup>
     <ProjectReference Condition=" '$(UseProjectReferences)' == 'true' " Include="..\SadConsole\SadConsole.csproj" />
-    <PackageReference Condition=" '$(UseProjectReferences)' != 'true' " Include="SadConsole" Version="9.2.1" />
+    <PackageReference Condition=" '$(UseProjectReferences)' != 'true' " Include="SadConsole" Version="9.2.2" />
     <PackageReference Include="TheSadRogue.Primitives" Version="1.1.1" />
     <PackageReference Include="TheSadRogue.Primitives.MonoGame" Version="1.0.0" />
     <PackageReference Include="MonoGame.Framework.DesktopGL" Version="3.8.0.1641" />

--- a/SadConsole.Host.MonoGame/SadConsole.Host.MonoGame.xml
+++ b/SadConsole.Host.MonoGame/SadConsole.Host.MonoGame.xml
@@ -124,6 +124,13 @@
             Ends the <see cref="P:SadConsole.Host.Global.SharedSpriteBatch"/> so another can be started, perhaps with an effect.
             </summary>
         </member>
+        <member name="M:SadConsole.Host.MonoGame.Extensions.ToMonoGame(SadConsole.Mirror)">
+            <summary>
+            Converts a <see cref="T:SadConsole.Mirror"/> type to a MonoGame <see cref="T:Microsoft.Xna.Framework.Graphics.SpriteEffects"/> type.
+            </summary>
+            <param name="mirror">The value to convert.</param>
+            <returns>The MonoGame equivalent.</returns>
+        </member>
         <member name="T:SadConsole.Host.GameTexture">
             <summary>
             Creates a <see cref="T:Microsoft.Xna.Framework.Graphics.Texture2D"/>. Generally you request this from the <see cref="M:SadConsole.GameHost.GetTexture(System.String)"/> method.

--- a/SadConsole/GlyphMirror.cs
+++ b/SadConsole/GlyphMirror.cs
@@ -9,16 +9,16 @@
         /// <summary>
         /// No mirroring set.
         /// </summary>
-        None,
+        None = 0,
 
         /// <summary>
         /// Mirror vertically.
         /// </summary>
-        Vertical,
+        Vertical = 1,
 
         /// <summary>
         /// Mirror horizontally.
         /// </summary>
-        Horizontal
+        Horizontal = 2,
     }
 }

--- a/SadConsole/SadConsole.csproj
+++ b/SadConsole/SadConsole.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.1;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>SadConsole</AssemblyName>
     <DocumentationFile>SadConsole.xml</DocumentationFile>
-    <Version>9.2.1</Version>
+    <Version>9.2.2</Version>
     <Version Condition="'$(Configuration)'=='Debug'">$(Version)-debug</Version>
     <Authors>Thraka</Authors>
     <Company>SadLogic</Company>
@@ -26,7 +26,7 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <EmbedAllSources>true</EmbedAllSources>
     <PackageTags>roguelike;cli;game;development;console;ansi;ascii;textmode;monogame;sfml;sadconsole</PackageTags>
-    <PackageReleaseNotes>9.2.0 contains lots of changes, including breaking changes. See NuGet or GitHub documentation for more information. 9.2.1 only fixes API documentation</PackageReleaseNotes>
+    <PackageReleaseNotes>9.2.0 contains lots of changes, including breaking changes. See NuGet or GitHub documentation for more information. 9.2.1 only fixes API documentation. 9.2.2 hardcodes the mirror enum values.</PackageReleaseNotes>
   </PropertyGroup>
 
   <!--

--- a/SadConsole/SadConsole.xml
+++ b/SadConsole/SadConsole.xml
@@ -2082,23 +2082,6 @@
             <param name="height">The viewable height of the surface.</param>
             <param name="clear">When <see langword="true"/>, resets every cell to the <see cref="P:SadConsole.Console.DefaultForeground"/>, <see cref="P:SadConsole.Console.DefaultBackground"/> and glyph 0.</param>
         </member>
-        <member name="T:SadConsole.Debug.Screen">
-            <summary>
-            A debugging screen that takes the place of the active <see cref="P:SadConsole.GameHost.Screen"/> and displays information about SadConsole.
-            </summary>
-        </member>
-        <member name="M:SadConsole.Debug.Screen.Show(SadConsole.IFont,SadRogue.Primitives.Point)">
-            <summary>
-            Displays the debugger.
-            </summary>
-            <param name="font">The font to use the debugging screen.</param>
-            <param name="fontSize">The size of the font.</param>
-        </member>
-        <member name="M:SadConsole.Debug.Screen.Show">
-            <summary>
-            Shows the debug screen with the default font and size.
-            </summary>
-        </member>
         <member name="T:SadConsole.DrawCalls.DrawCallCustom">
             <summary>
             A draw call that invokes an <see cref="T:System.Action"/> delegate.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,7 @@
+## v9.2.2 (01/XX/2022)
+
+- [MonoGame] Fix conversion of Mirror to SpriteEffects.
+
 ## v9.2.1 (01/04/2022)
 
 - Rebuild RELEASE build to fix API documentation generation.


### PR DESCRIPTION
- Fixes mirror conversion in the monogame library.