### PR TITLE
Fix for issue with Game.Create when specifying a custom font 

### DIFF
--- a/SadConsole/GameHost.cs
+++ b/SadConsole/GameHost.cs
@@ -204,7 +204,7 @@ namespace SadConsole
                     TypeNameHandling = Newtonsoft.Json.TypeNameHandling.All
                 };
 
-                IFont masterFont = SadConsole.Serializer.Load<IFont>(font, false);
+                IFont masterFont = SadConsole.Serializer.Load<SadFont>(font, false);
 
                 if (GameHost.Instance.Fonts.ContainsKey(masterFont.Name))
                     GameHost.Instance.Fonts.Remove(masterFont.Name);


### PR DESCRIPTION
I encountered an issue where 
`SadConsole.Game.Create(width, height, "fonts/myFont.font")`
would throw the following error:
`Could not create an instance of type SadConsole.IFont. Type is an interface or abstract class and cannot be instantiated`

I believe I found the fix for this, but because the repo as it stands can't be compiled in its entirety on a clean clone, **I was not able to test the changes myself**. Please review the change when you can.