### PR TITLE
Bugfix #298: Surface.SetGlyph(x, y, ColoredGlyph) does not take .IsVisible into account

### DIFF
--- a/SadConsole/ColoredGlyph.cs
+++ b/SadConsole/ColoredGlyph.cs
@@ -188,6 +188,7 @@ namespace SadConsole
             cell.Background = Background;
             cell.Glyph = Glyph;
             cell.Mirror = Mirror;
+            cell.IsVisible = IsVisible;
             if (deepCopy)
                 cell.Decorators = Decorators.Length != 0 ? Decorators.ToArray() : Array.Empty<CellDecorator>();
             else

--- a/Tests/SadConsole.Tests/CellSurface.Basics.cs
+++ b/Tests/SadConsole.Tests/CellSurface.Basics.cs
@@ -95,6 +95,10 @@ namespace SadConsole.Tests
             surface1.SetGlyph(0, 0, newGlyph);
 
             Assert.IsTrue(newGlyph == surface1[0, 0].Glyph);
+
+            surface1.SetGlyph(0, 0, new ColoredGlyph(Color.Coral, Color.Chocolate, newGlyph) { IsVisible = false });
+
+            Assert.IsFalse(surface1[0, 0].IsVisible);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fixed it, and adjusted a unit test to also include this case