### PR TITLE
Fix ShiftDown and Add Shift Surface Tests

### DIFF
--- a/SadConsole/ICellSurface.Editor.cs
+++ b/SadConsole/ICellSurface.Editor.cs
@@ -1655,8 +1655,8 @@ public static class CellSurfaceEditor
             {
                 for (int x = 0; x < surface.Width; x++)
                 {
-                    ColoredGlyph source = surface[y * surface.Width + x];
-                    source.Clear();
+                    Clear(surface, x, y);
+
                 }
             }
         }

--- a/Tests/SadConsole.Tests/CellSurface.Editor.ShiftConsole.cs
+++ b/Tests/SadConsole.Tests/CellSurface.Editor.ShiftConsole.cs
@@ -25,7 +25,7 @@ public partial class CellSurface
             .Combinate(new[] { true, false });
     #endregion
 
-    #region Shift Surface Vertically Both Directions
+    #region Shift Surface Vertically One Direction
     [TestMethod]
     [BetterDynamicData(nameof(ShiftInputs))]
     public void ShiftConsoleDown(int shiftAmount, bool wrap)
@@ -113,6 +113,95 @@ public partial class CellSurface
     }
     #endregion
 
+    #region Shift Surface Horizontally One Direction
+    [TestMethod]
+    [BetterDynamicData(nameof(ShiftInputs))]
+    public void ShiftConsoleRight(int shiftAmount, bool wrap)
+    {
+        // Create test surface
+        var surface = CreateShiftableCellSurfaceForEntireSurface();
+
+        // Shift with some helpful before/after output
+        PrintSurfaceGlyphs(surface, "Before:");
+        surface.ShiftRight(shiftAmount, wrap);
+        PrintSurfaceGlyphs(surface, "After:");
+
+        // Verify IsDirty is set if cells changed.  If nothing changed, the implementation doesn't _have_ to set
+        // IsDirty to be correct, but setting it harms nothing but efficiency; so we just won't check it
+        if (shiftAmount != surface.Width)
+            Assert.IsTrue(surface.IsDirty);
+
+        // Verify shift result
+        AssertHasShiftedHorizontally(surface, shiftAmount, wrap);
+    }
+
+    [TestMethod]
+    [BetterDynamicData(nameof(ShiftInputs))]
+    public void ShiftConsoleLeft(int shiftAmount, bool wrap)
+    {
+        // Create test surface
+        var surface = CreateShiftableCellSurfaceForEntireSurface();
+
+        // Shift with some helpful before/after output
+        PrintSurfaceGlyphs(surface, "Before:");
+        surface.ShiftLeft(shiftAmount, wrap);
+        PrintSurfaceGlyphs(surface, "After:");
+
+        // Verify IsDirty is set if cells changed.  If nothing changed, the implementation doesn't _have_ to set
+        // IsDirty to be correct, but setting it harms nothing but efficiency; so we just won't check it
+        if (shiftAmount != surface.Width)
+            Assert.IsTrue(surface.IsDirty);
+
+        // Verify shift result
+        AssertHasShiftedHorizontally(surface, -shiftAmount, wrap);
+    }
+
+    #endregion
+
+    #region Shift Surface Horizontally Both Directions
+    [TestMethod]
+    [BetterDynamicData(nameof(ShiftInputsWithNeg))]
+    public void ShiftConsoleRightBothDirs(int shiftAmount, bool wrap)
+    {
+        // Create test surface
+        var surface = CreateShiftableCellSurfaceForEntireSurface();
+
+        // Shift with some helpful before/after output
+        PrintSurfaceGlyphs(surface, "Before:");
+        surface.ShiftRight(shiftAmount, wrap);
+        PrintSurfaceGlyphs(surface, "After:");
+
+        // Verify IsDirty is set if cells changed.  If nothing changed, the implementation doesn't _have_ to set
+        // IsDirty to be correct, but setting it harms nothing but efficiency; so we just won't check it
+        if (Math.Abs(shiftAmount) != surface.Width)
+            Assert.IsTrue(surface.IsDirty);
+
+        // Verify shift result
+        AssertHasShiftedHorizontally(surface, shiftAmount, wrap);
+    }
+
+    [TestMethod]
+    [BetterDynamicData(nameof(ShiftInputsWithNeg))]
+    public void ShiftConsoleLeftBothDirs(int shiftAmount, bool wrap)
+    {
+        // Create test surface
+        var surface = CreateShiftableCellSurfaceForEntireSurface();
+
+        // Shift with some helpful before/after output
+        PrintSurfaceGlyphs(surface, "Before:");
+        surface.ShiftLeft(shiftAmount, wrap);
+        PrintSurfaceGlyphs(surface, "After:");
+
+        // Verify IsDirty is set if cells changed.  If nothing changed, the implementation doesn't _have_ to set
+        // IsDirty to be correct, but setting it harms nothing but efficiency; so we just won't check it
+        if (Math.Abs(shiftAmount) != surface.Width)
+            Assert.IsTrue(surface.IsDirty);
+
+        // Verify shift result
+        AssertHasShiftedHorizontally(surface, -shiftAmount, wrap);
+    }
+    #endregion
+
     #region Shift Test Helpers
     private static SadConsole.CellSurface CreateShiftableCellSurfaceForEntireSurface()
     {
@@ -149,7 +238,7 @@ public partial class CellSurface
     }
 
     // Checks that a surface has been shifted as specified, assuming the cells were generated via GetShiftCellFor.
-    // Positive values check for shift down, negative values ShiftUp
+    // Positive values check for shift down, negative values shift up
     private static void AssertHasShiftedVertically(ICellSurface surface, int shiftAmount, bool wrap)
     {
         // Generate blank glyph appropriate for the surface we're checking
@@ -167,6 +256,29 @@ public partial class CellSurface
             int oldY = y - shiftAmount;
             if (wrap) oldY = WrapAround(oldY, surface.Height);
             var expectedGlyph = oldY >= 0 && oldY < surface.Height || wrap ? GetShiftCellForEntireSurface(Point.ToIndex(x, oldY, surface.Width)) : blankGlyph;
+            Assert.IsTrue(CheckAppearancesEqual(expectedGlyph, surface[x, y]));
+        }
+    }
+
+    // Checks that a surface has been shifted as specified, assuming the cells were generated via GetShiftCellFor.
+    // Positive values check for shift right, negative values shift left
+    private static void AssertHasShiftedHorizontally(ICellSurface surface, int shiftAmount, bool wrap)
+    {
+        // Generate blank glyph appropriate for the surface we're checking
+        ColoredGlyph blankGlyph = new ColoredGlyph
+        {
+            Glyph = surface.DefaultGlyph,
+            Background = surface.DefaultBackground,
+            Foreground = surface.DefaultForeground,
+            Decorators = Array.Empty<CellDecorator>(),
+            Mirror = Mirror.None
+        };
+
+        foreach (var (x, y) in surface.Positions())
+        {
+            int oldX = x - shiftAmount;
+            if (wrap) oldX = WrapAround(oldX, surface.Width);
+            var expectedGlyph = oldX >= 0 && oldX < surface.Width || wrap ? GetShiftCellForEntireSurface(Point.ToIndex(oldX, y, surface.Width)) : blankGlyph;
             Assert.IsTrue(CheckAppearancesEqual(expectedGlyph, surface[x, y]));
         }
     }

--- a/Tests/SadConsole.Tests/CellSurface.Editor.ShiftConsole.cs
+++ b/Tests/SadConsole.Tests/CellSurface.Editor.ShiftConsole.cs
@@ -1,0 +1,174 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SadRogue.Primitives;
+using SadRogue.Primitives.GridViews;
+
+namespace SadConsole.Tests;
+
+public partial class CellSurface
+{
+    #region Test Data
+    // Want to test shift values both < axis / 2 and > axis / 2, to ensure no wrapping/optimization issues.
+    // Also should be composed of at least one odd number.  We also want to test one value that is exactly shift
+    // count.
+    //
+    // The values here are derived from the values specified in CellSurface.Editor.ShiftRows, so if those tests
+    // meet the criteria, so too should these.
+
+    public static IEnumerable<(int shiftAmount, bool wrap)> ShiftInputs
+        => s_shiftValuesCol
+            .Combinate(new[] { true, false });
+
+    public static IEnumerable<(int shiftAmount, bool wrap)> ShiftInputsWithNeg
+        => s_shiftValuesColWithNeg
+            .Combinate(new[] { true, false });
+    #endregion
+
+    #region Shift Surface Vertically Both Directions
+    [TestMethod]
+    [BetterDynamicData(nameof(ShiftInputs))]
+    public void ShiftConsoleDown(int shiftAmount, bool wrap)
+    {
+        // Create test surface
+        var surface = CreateShiftableCellSurfaceForEntireSurface();
+
+        // Shift with some helpful before/after output
+        PrintSurfaceGlyphs(surface, "Before:");
+        surface.ShiftDown(shiftAmount, wrap);
+        PrintSurfaceGlyphs(surface, "After:");
+
+        // Verify IsDirty is set if cells changed.  If nothing changed, the implementation doesn't _have_ to set
+        // IsDirty to be correct, but setting it harms nothing but efficiency; so we just won't check it
+        if (shiftAmount != surface.Height)
+            Assert.IsTrue(surface.IsDirty);
+
+        // Verify shift result
+        AssertHasShiftedVertically(surface, shiftAmount, wrap);
+    }
+
+    [TestMethod]
+    [BetterDynamicData(nameof(ShiftInputs))]
+    public void ShiftConsoleUp(int shiftAmount, bool wrap)
+    {
+        // Create test surface
+        var surface = CreateShiftableCellSurfaceForEntireSurface();
+
+        // Shift with some helpful before/after output
+        PrintSurfaceGlyphs(surface, "Before:");
+        surface.ShiftUp(shiftAmount, wrap);
+        PrintSurfaceGlyphs(surface, "After:");
+
+        // Verify IsDirty is set if cells changed.  If nothing changed, the implementation doesn't _have_ to set
+        // IsDirty to be correct, but setting it harms nothing but efficiency; so we just won't check it
+        if (shiftAmount != surface.Height)
+            Assert.IsTrue(surface.IsDirty);
+
+        // Verify shift result
+        AssertHasShiftedVertically(surface, -shiftAmount, wrap);
+    }
+    #endregion
+
+    #region Shift Surface Vertically Both Directions
+    [TestMethod]
+    [BetterDynamicData(nameof(ShiftInputsWithNeg))]
+    public void ShiftConsoleDownBothDirs(int shiftAmount, bool wrap)
+    {
+        // Create test surface
+        var surface = CreateShiftableCellSurfaceForEntireSurface();
+
+        // Shift with some helpful before/after output
+        PrintSurfaceGlyphs(surface, "Before:");
+        surface.ShiftDown(shiftAmount, wrap);
+        PrintSurfaceGlyphs(surface, "After:");
+
+        // Verify IsDirty is set if cells changed.  If nothing changed, the implementation doesn't _have_ to set
+        // IsDirty to be correct, but setting it harms nothing but efficiency; so we just won't check it
+        if (Math.Abs(shiftAmount) != surface.Height)
+            Assert.IsTrue(surface.IsDirty);
+
+        // Verify shift result
+        AssertHasShiftedVertically(surface, shiftAmount, wrap);
+    }
+
+    [TestMethod]
+    [BetterDynamicData(nameof(ShiftInputsWithNeg))]
+    public void ShiftConsoleUpBothDirs(int shiftAmount, bool wrap)
+    {
+        // Create test surface
+        var surface = CreateShiftableCellSurfaceForEntireSurface();
+
+        // Shift with some helpful before/after output
+        PrintSurfaceGlyphs(surface, "Before:");
+        surface.ShiftUp(shiftAmount, wrap);
+        PrintSurfaceGlyphs(surface, "After:");
+
+        // Verify IsDirty is set if cells changed.  If nothing changed, the implementation doesn't _have_ to set
+        // IsDirty to be correct, but setting it harms nothing but efficiency; so we just won't check it
+        if (Math.Abs(shiftAmount) != surface.Height)
+            Assert.IsTrue(surface.IsDirty);
+
+        // Verify shift result
+        AssertHasShiftedVertically(surface, -shiftAmount, wrap);
+    }
+    #endregion
+
+    #region Shift Test Helpers
+    private static SadConsole.CellSurface CreateShiftableCellSurfaceForEntireSurface()
+    {
+        // Create surface and set cells for testing
+        var surface = new SadConsole.CellSurface(SurfaceWidth, SurfaceHeight);
+
+        // Number it with first cell in col glyph 1, second glyph 2, etc.
+        foreach (var pos in surface.Positions())
+            surface[pos].CopyAppearanceFrom(GetShiftCellForEntireSurface(pos.ToIndex(surface.Width)));
+
+        // Set IsDirty to false because we want to test that certain functions set it to true, and we're not
+        // actually rendering it so it won't matter
+        surface.IsDirty = false;
+
+        return surface;
+    }
+
+    // Computes a ColoredGlyph with unique values for its appearance-related fields, given an ID. This ID
+    // should be the "index" value of that position, eg. the result of point.ToIndex(surface.Width).
+    private static ColoredGlyph GetShiftCellForEntireSurface(int positionId)
+    {
+        int id = positionId + 1;
+        var colorId = new Color(id, id, id);
+        var mirrorId = s_mirrorValues[positionId % s_mirrorValues.Length];
+        var glyph = new ColoredGlyph
+        {
+            Glyph = id,
+            Background = colorId,
+            Foreground = colorId,
+            Decorators = new[] { new CellDecorator(colorId, id, mirrorId) },
+            Mirror = mirrorId,
+        };
+        return glyph;
+    }
+
+    // Checks that a surface has been shifted as specified, assuming the cells were generated via GetShiftCellFor.
+    // Positive values check for shift down, negative values ShiftUp
+    private static void AssertHasShiftedVertically(ICellSurface surface, int shiftAmount, bool wrap)
+    {
+        // Generate blank glyph appropriate for the surface we're checking
+        ColoredGlyph blankGlyph = new ColoredGlyph
+        {
+            Glyph = surface.DefaultGlyph,
+            Background = surface.DefaultBackground,
+            Foreground = surface.DefaultForeground,
+            Decorators = Array.Empty<CellDecorator>(),
+            Mirror = Mirror.None
+        };
+
+        foreach (var (x, y) in surface.Positions())
+        {
+            int oldY = y - shiftAmount;
+            if (wrap) oldY = WrapAround(oldY, surface.Height);
+            var expectedGlyph = oldY >= 0 && oldY < surface.Height || wrap ? GetShiftCellForEntireSurface(Point.ToIndex(x, oldY, surface.Width)) : blankGlyph;
+            Assert.IsTrue(CheckAppearancesEqual(expectedGlyph, surface[x, y]));
+        }
+    }
+    #endregion
+}

--- a/Tests/SadConsole.Tests/CellSurface.Editor.ShiftRows.cs
+++ b/Tests/SadConsole.Tests/CellSurface.Editor.ShiftRows.cs
@@ -94,6 +94,9 @@ namespace SadConsole.Tests
             // fully new values.
             Assert.IsTrue(ShiftInputsRow.Any(v => v.shift % 2 == 1));
             Assert.IsTrue(ShiftInputsCol.Any(v => v.shift % 2 == 1));
+
+            // Necessary to ensure our color indexing will work properly (both here and in ShiftConsole)
+            Assert.IsTrue(SurfaceWidth * SurfaceHeight <= 255);
         }
         #endregion
 
@@ -285,7 +288,7 @@ namespace SadConsole.Tests
 
             // Number it with first cell in row glyph 1, second glyph 2, etc.
             for (int x = 0; x < surface.Width; x++)
-                surface[x, ShiftRow].CopyAppearanceFrom(GetShiftCellFor(x));
+                surface[x, ShiftRow].CopyAppearanceFrom(GetShiftCellForSingleRowCol(x));
 
             // Set IsDirty to false because we want to test that certain functions set it to true, and we're not
             // actually rendering it so it won't matter
@@ -301,7 +304,7 @@ namespace SadConsole.Tests
 
             // Number it with first cell in col glyph 1, second glyph 2, etc.
             for (int y = 0; y < surface.Height; y++)
-                surface[ShiftCol, y].CopyAppearanceFrom(GetShiftCellFor(y));
+                surface[ShiftCol, y].CopyAppearanceFrom(GetShiftCellForSingleRowCol(y));
 
             // Set IsDirty to false because we want to test that certain functions set it to true, and we're not
             // actually rendering it so it won't matter
@@ -312,7 +315,7 @@ namespace SadConsole.Tests
 
         // Computes a ColoredGlyph with unique values for its appearance-related fields, given an ID. This ID
         // should be either the X-value or the Y-value for a position on a surface.
-        private static ColoredGlyph GetShiftCellFor(int positionId)
+        private static ColoredGlyph GetShiftCellForSingleRowCol(int positionId)
         {
             int id = positionId + 1;
             var colorId = new Color(id, id, id);
@@ -359,14 +362,14 @@ namespace SadConsole.Tests
                     int oldX = x - shiftAmount;
 
                     if (wrap) oldX = WrapAround(oldX - startingX, count) + startingX;
-                    var expectedGlyph = oldX >= startingX && oldX < startingX + count || wrap ? GetShiftCellFor(oldX) : blankGlyph;
+                    var expectedGlyph = oldX >= startingX && oldX < startingX + count || wrap ? GetShiftCellForSingleRowCol(oldX) : blankGlyph;
 
                     Assert.IsTrue(CheckAppearancesEqual(expectedGlyph, surface[x, y]));
                 }
                 // Value should not have changed.
                 else
                 {
-                    var expectedGlyph = y == ShiftRow ? GetShiftCellFor(x) : blankGlyph;
+                    var expectedGlyph = y == ShiftRow ? GetShiftCellForSingleRowCol(x) : blankGlyph;
                     Assert.IsTrue(CheckAppearancesEqual(expectedGlyph, surface[x, y]));
                 }
             }
@@ -394,14 +397,14 @@ namespace SadConsole.Tests
                     int oldY = y - shiftAmount;
 
                     if (wrap) oldY = WrapAround(oldY - startingY, count) + startingY;
-                    var expectedGlyph = oldY >= startingY && oldY < startingY + count || wrap ? GetShiftCellFor(oldY) : blankGlyph;
+                    var expectedGlyph = oldY >= startingY && oldY < startingY + count || wrap ? GetShiftCellForSingleRowCol(oldY) : blankGlyph;
 
                     Assert.IsTrue(CheckAppearancesEqual(expectedGlyph, surface[x, y]));
                 }
                 // Value should not have changed.
                 else
                 {
-                    var expectedGlyph = x == ShiftCol ? GetShiftCellFor(y) : blankGlyph;
+                    var expectedGlyph = x == ShiftCol ? GetShiftCellForSingleRowCol(y) : blankGlyph;
                     Assert.IsTrue(CheckAppearancesEqual(expectedGlyph, surface[x, y]));
                 }
             }


### PR DESCRIPTION
# Overview
Just a quick fix to fix a bug in the `ShiftDown`, and add unit tests for console-wide shift functions to prevent regression.  I also think it may be possible to significantly optimize the performance of these functions, but that can be done in a separate PR if anything.

Given that this is a bugfix, I wasn't sure whether you wanted it targeting develop or master.  If you want master so you can release a v9 fix, I can cherry-pick my commits out or just create a second PR; the actual change to SadConsole, as opposed to the unit tests, is effectively one line.

# Changes
- Added unit tests for `CellSurface.ShiftUp`, `CellSurface.ShiftDown`, `CellSurface.ShiftLeft`, and `CellSurface.ShiftRight`.
- Fixed but in `ShiftDown` which prevented it from setting the background of cells properly when `wrap==false` (closes #303 )