### PR TITLE
Surface Shift Optimizations

### DIFF
--- a/PerformanceTests/SadConsole.PerformanceTests/ScreenSurfaceShift.cs
+++ b/PerformanceTests/SadConsole.PerformanceTests/ScreenSurfaceShift.cs
@@ -67,47 +67,47 @@ public class ScreenSurfaceShift
     }
     #endregion
 
-    // #region Horizontal Shifts
-    // [Benchmark]
-    // public ICellSurface ShiftRightOne()
-    // {
-    //     _surface.ShiftRight(1, Wrap);
-    //     return _surface;
-    // }
-    //
-    // [Benchmark]
-    // public ICellSurface ShiftRightHalf()
-    // {
-    //     _surface.ShiftRight(_surface.Width / 2, Wrap);
-    //     return _surface;
-    // }
-    //
-    // [Benchmark]
-    // public ICellSurface ShiftRightWidthMinusOne()
-    // {
-    //     _surface.ShiftRight(_surface.Width - 1, Wrap);
-    //     return _surface;
-    // }
-    //
-    // [Benchmark]
-    // public ICellSurface ShiftLeftOne()
-    // {
-    //     _surface.ShiftLeft(1, Wrap);
-    //     return _surface;
-    // }
-    //
-    // [Benchmark]
-    // public ICellSurface ShiftLeftHalf()
-    // {
-    //     _surface.ShiftLeft(_surface.Width / 2, Wrap);
-    //     return _surface;
-    // }
-    //
-    // [Benchmark]
-    // public ICellSurface ShiftLeftWidthMinusOne()
-    // {
-    //     _surface.ShiftLeft(_surface.Width - 1, Wrap);
-    //     return _surface;
-    // }
-    // #endregion
+    #region Horizontal Shifts
+    [Benchmark]
+    public ICellSurface ShiftRightOne()
+    {
+        _surface.ShiftRight(1, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftRightHalf()
+    {
+        _surface.ShiftRight(_surface.Width / 2, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftRightWidthMinusOne()
+    {
+        _surface.ShiftRight(_surface.Width - 1, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftLeftOne()
+    {
+        _surface.ShiftLeft(1, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftLeftHalf()
+    {
+        _surface.ShiftLeft(_surface.Width / 2, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftLeftWidthMinusOne()
+    {
+        _surface.ShiftLeft(_surface.Width - 1, Wrap);
+        return _surface;
+    }
+    #endregion
 }

--- a/PerformanceTests/SadConsole.PerformanceTests/ScreenSurfaceShift.cs
+++ b/PerformanceTests/SadConsole.PerformanceTests/ScreenSurfaceShift.cs
@@ -1,0 +1,113 @@
+﻿using BenchmarkDotNet.Attributes;
+
+namespace SadConsole.PerformanceTests;
+
+public class ScreenSurfaceShift
+{
+    private BasicGameHost _gameHost;
+
+    [Params(10, 100, 500)]
+    public int Size;
+
+    [Params(true, false)]
+    public bool Wrap;
+
+    private ICellSurface _surface = null!;
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        _gameHost = new BasicGameHost();
+
+        _surface = new CellSurface(Size, Size);
+        _surface.FillWithRandomGarbage(255);
+    }
+
+    #region Vertical Shifts
+    [Benchmark]
+    public ICellSurface ShiftUpOne()
+    {
+        _surface.ShiftUp(1, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftUpHalf()
+    {
+        _surface.ShiftUp(_surface.Height / 2, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftUpHeightMinusOne()
+    {
+        _surface.ShiftUp(_surface.Height - 1, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftDownOne()
+    {
+        _surface.ShiftDown(1, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftDownHalf()
+    {
+        _surface.ShiftDown(_surface.Height / 2, Wrap);
+        return _surface;
+    }
+
+    [Benchmark]
+    public ICellSurface ShiftDownHeightMinusOne()
+    {
+        _surface.ShiftDown(_surface.Height - 1, Wrap);
+        return _surface;
+    }
+    #endregion
+
+    // #region Horizontal Shifts
+    // [Benchmark]
+    // public ICellSurface ShiftRightOne()
+    // {
+    //     _surface.ShiftRight(1, Wrap);
+    //     return _surface;
+    // }
+    //
+    // [Benchmark]
+    // public ICellSurface ShiftRightHalf()
+    // {
+    //     _surface.ShiftRight(_surface.Width / 2, Wrap);
+    //     return _surface;
+    // }
+    //
+    // [Benchmark]
+    // public ICellSurface ShiftRightWidthMinusOne()
+    // {
+    //     _surface.ShiftRight(_surface.Width - 1, Wrap);
+    //     return _surface;
+    // }
+    //
+    // [Benchmark]
+    // public ICellSurface ShiftLeftOne()
+    // {
+    //     _surface.ShiftLeft(1, Wrap);
+    //     return _surface;
+    // }
+    //
+    // [Benchmark]
+    // public ICellSurface ShiftLeftHalf()
+    // {
+    //     _surface.ShiftLeft(_surface.Width / 2, Wrap);
+    //     return _surface;
+    // }
+    //
+    // [Benchmark]
+    // public ICellSurface ShiftLeftWidthMinusOne()
+    // {
+    //     _surface.ShiftLeft(_surface.Width - 1, Wrap);
+    //     return _surface;
+    // }
+    // #endregion
+}

--- a/SadConsole/ICellSurface.Editor.cs
+++ b/SadConsole/ICellSurface.Editor.cs
@@ -1375,7 +1375,7 @@ public static class CellSurfaceEditor
     }
 
     /// <summary>
-    /// Internal use. Doesn't do any checks on valid values. Shifts the spefied row from a Y position, by the specfied amount, down.
+    /// Internal use. Doesn't do any checks on valid values. Shifts the specified row from a Y position, by the specified amount, down.
     /// </summary>
     /// <param name="surface">The surface being edited.</param>
     /// <param name="col">The column to shift.</param>
@@ -1383,7 +1383,8 @@ public static class CellSurfaceEditor
     /// <param name="count">The number of cells to shift starting from <paramref name="startingY"/>.</param>
     /// <param name="amount">The amount to shift by. A negative value shifts left and a positive value shifts right.</param>
     /// <param name="wrap">When <see langword="true" />, wraps the glyph data from one side to another, otherwise clears the glyphs left behind.</param>
-    public static void ShiftColumnDownUnchecked(this ICellSurface surface, int col, int startingY, int count, int amount, bool wrap)
+    public static void ShiftColumnDownUnchecked(this ICellSurface surface, int col, int startingY, int count,
+                                                int amount, bool wrap)
     {
         if (wrap)
         {
@@ -1393,18 +1394,26 @@ public static class CellSurfaceEditor
             // If count was a multiple of width, everything will end up back where it started so we're done
             if (amount == 0) return;
 
-            // Any wrapping shift-right by n is equivalent to a shift-left by width - n.  Because we have to
+            // Any wrapping shift-down by n is equivalent to a shift-up by count - n.  Because we have to
             // allocate a temporary array the size of the value we're shifting during the algorithm,
             // we'll optimize it by making sure that value is as small as possible.  The largest shift
-            // value we will actually process will then be width / 2.
+            // value we will actually process will then be count / 2.
             if (count - amount < amount)
             {
                 ShiftColumnUpUnchecked(surface, col, startingY, count, count - amount, true);
                 return;
             }
+        }
 
+        ShiftColumnDownUncheckedReuseArray(surface, null, col, startingY, count, amount, wrap);
+    }
+
+    private static void ShiftColumnDownUncheckedReuseArray(ICellSurface surface, ColoredGlyphAppearance[]? tempArray, int col, int startingY, int count, int amount, bool wrap)
+    {
+        if (wrap)
+        {
             // Temporary array size of shift value
-            var tempArray = new ColoredGlyphAppearance[amount];
+            tempArray ??= new ColoredGlyphAppearance[amount];
             // Offset for tempArray
             int tempArrayOffset = count - amount;
 
@@ -1443,7 +1452,7 @@ public static class CellSurfaceEditor
     }
 
     /// <summary>
-    /// Internal use. Doesn't do any checks on valid values. Shifts the spefied row from a Y position, by the specfied amount, up.
+    /// Internal use. Doesn't do any checks on valid values. Shifts the specified row from a Y position, by the specified amount, up.
     /// </summary>
     /// <param name="surface">The surface being edited.</param>
     /// <param name="col">The column to shift.</param>
@@ -1451,7 +1460,8 @@ public static class CellSurfaceEditor
     /// <param name="count">The number of cells to shift starting from <paramref name="startingY"/>.</param>
     /// <param name="amount">The amount to shift by. A negative value shifts left and a positive value shifts right.</param>
     /// <param name="wrap">When <see langword="true" />, wraps the glyph data from one side to another, otherwise clears the glyphs left behind.</param>
-    public static void ShiftColumnUpUnchecked(this ICellSurface surface, int col, int startingY, int count, int amount, bool wrap)
+    public static void ShiftColumnUpUnchecked(this ICellSurface surface, int col, int startingY, int count, int amount,
+                                              bool wrap)
     {
         if (wrap)
         {
@@ -1470,9 +1480,17 @@ public static class CellSurfaceEditor
                 ShiftColumnDownUnchecked(surface, col, startingY, count, count - amount, true);
                 return;
             }
+        }
 
+        ShiftColumnUpUncheckedReuseArray(surface, null, col, startingY, count, amount, wrap);
+    }
+
+    private static void ShiftColumnUpUncheckedReuseArray(ICellSurface surface, ColoredGlyphAppearance[]? tempArray, int col, int startingY, int count, int amount, bool wrap)
+    {
+        if (wrap)
+        {
             // Temporary array size of shift value
-            var tempArray = new ColoredGlyphAppearance[amount];
+            tempArray ??= new ColoredGlyphAppearance[amount];
 
             // Shift each cell to its proper location, using temporary storage as needed.
             for (int i = 0; i < count; i++)
@@ -1524,9 +1542,7 @@ public static class CellSurfaceEditor
     public static void ShiftUp(this ICellSurface surface, int amount, bool wrap = false)
     {
         if (amount == 0)
-        {
             return;
-        }
 
         if (amount < 0)
         {
@@ -1535,59 +1551,42 @@ public static class CellSurfaceEditor
         }
 
         surface.TimesShiftedUp += amount;
+        ShiftUpUnchecked(surface, amount, wrap);
+    }
 
-        List<Tuple<ColoredGlyph, int>> wrappedCells = null!;
-
-        // Handle all the wrapped ones first
+    private static void ShiftUpUnchecked(ICellSurface surface, int amount, bool wrap = false)
+    {
+        int count = surface.Height;
         if (wrap)
         {
-            wrappedCells = new List<Tuple<ColoredGlyph, int>>(surface.Height * amount);
+            // Simplify wrap to minimum needed number
+            amount %= surface.Height;
 
-            for (int y = 0; y < amount; y++)
+            // If count was a multiple of height, everything will end up back where it started so we're done
+            if (amount == 0) return;
+
+            ColoredGlyphAppearance[]? tempArray;
+
+            // Any wrapping shift-up by n is equivalent to a shift-down by height - n.  Because we have to
+            // allocate a temporary array the size of the value we're shifting during the algorithm,
+            // we'll optimize it by making sure that value is as small as possible.  The largest shift
+            // value we will actually process will then be height / 2.
+            if (count - amount < amount)
             {
+                amount = count - amount;
+                tempArray = new ColoredGlyphAppearance[amount];
                 for (int x = 0; x < surface.Width; x++)
-                {
-                    var tempCell = new ColoredGlyph();
-                    surface[y * surface.Width + x].CopyAppearanceTo(tempCell);
-
-                    wrappedCells.Add(new Tuple<ColoredGlyph, int>(tempCell, (surface.Height - amount + y) * surface.Width + x));
-                }
+                    ShiftColumnDownUncheckedReuseArray(surface, tempArray, x, 0, count, amount, true);
+                return;
             }
-        }
 
-        for (int y = amount; y < surface.Height; y++)
-        {
+            tempArray = new ColoredGlyphAppearance[amount];
             for (int x = 0; x < surface.Width; x++)
-            {
-                ColoredGlyph destination = surface[(y - amount) * surface.Width + x];
-                ColoredGlyph source = surface[y * surface.Width + x];
-                destination.CopyAppearanceFrom(source, false);
-            }
-        }
-
-
-        if (!wrap)
-        {
-            for (int y = surface.Height - amount; y < surface.Height; y++)
-            {
-                for (int x = 0; x < surface.Width; x++)
-                {
-                    Clear(surface, x, y);
-                }
-            }
+                ShiftColumnUpUncheckedReuseArray(surface, tempArray, x, 0, count, amount, true);
         }
         else
-        {
-            Tuple<ColoredGlyph, int> cellTuple;
-            for (int i = 0; i < wrappedCells.Count; i++)
-            {
-                cellTuple = wrappedCells[i];
-                ColoredGlyph destination = surface[cellTuple.Item2];
-                destination.CopyAppearanceFrom(cellTuple.Item1, false);
-            }
-        }
-
-        surface.IsDirty = true;
+            for (int x = 0; x < surface.Width; x++)
+                ShiftColumnUpUncheckedReuseArray(surface, null, x, 0, count, amount, false);
     }
 
     /// <summary>
@@ -1607,9 +1606,7 @@ public static class CellSurfaceEditor
     public static void ShiftDown(this ICellSurface surface, int amount, bool wrap = false)
     {
         if (amount == 0)
-        {
             return;
-        }
 
         if (amount < 0)
         {
@@ -1618,60 +1615,42 @@ public static class CellSurfaceEditor
         }
 
         surface.TimesShiftedDown += amount;
+        ShiftDownUnchecked(surface, amount, wrap);
+    }
 
-        List<Tuple<ColoredGlyph, int>> wrappedCells = null!;
-
-        // Handle all the wrapped ones first
+    private static void ShiftDownUnchecked(ICellSurface surface, int amount, bool wrap = false)
+    {
+        int count = surface.Height;
         if (wrap)
         {
-            wrappedCells = new List<Tuple<ColoredGlyph, int>>(surface.Height * amount);
+            // Simplify wrap to minimum needed number
+            amount %= surface.Height;
 
-            for (int y = surface.Height - amount; y < surface.Height; y++)
+            // If count was a multiple of height, everything will end up back where it started so we're done
+            if (amount == 0) return;
+
+            ColoredGlyphAppearance[]? tempArray;
+
+            // Any wrapping shift-up by n is equivalent to a shift-down by height - n.  Because we have to
+            // allocate a temporary array the size of the value we're shifting during the algorithm,
+            // we'll optimize it by making sure that value is as small as possible.  The largest shift
+            // value we will actually process will then be height / 2.
+            if (count - amount < amount)
             {
+                amount = count - amount;
+                tempArray = new ColoredGlyphAppearance[amount];
                 for (int x = 0; x < surface.Width; x++)
-                {
-                    var tempCell = new ColoredGlyph();
-                    surface[y * surface.Width + x].CopyAppearanceTo(tempCell);
-
-                    wrappedCells.Add(new Tuple<ColoredGlyph, int>(tempCell, (amount - (surface.Height - y)) * surface.Width + x));
-                }
+                    ShiftColumnUpUncheckedReuseArray(surface, tempArray, x, 0, count, amount, true);
+                return;
             }
-        }
 
-        for (int y = (surface.Height - 1) - amount; y >= 0; y--)
-        {
+            tempArray = new ColoredGlyphAppearance[amount];
             for (int x = 0; x < surface.Width; x++)
-            {
-                ColoredGlyph destination = surface[(y + amount) * surface.Width + x];
-                ColoredGlyph source = surface[y * surface.Width + x];
-
-                destination.CopyAppearanceFrom(source, false);
-            }
-        }
-
-        if (!wrap)
-        {
-            for (int y = 0; y < amount; y++)
-            {
-                for (int x = 0; x < surface.Width; x++)
-                {
-                    Clear(surface, x, y);
-
-                }
-            }
+                ShiftColumnDownUncheckedReuseArray(surface, tempArray, x, 0, count, amount, true);
         }
         else
-        {
-            Tuple<ColoredGlyph, int> cellTuple;
-            for (int i = 0; i < wrappedCells.Count; i++)
-            {
-                cellTuple = wrappedCells[i];
-                ColoredGlyph destination = surface[cellTuple.Item2];
-                destination.CopyAppearanceFrom(cellTuple.Item1, false);
-            }
-        }
-
-        surface.IsDirty = true;
+            for (int x = 0; x < surface.Width; x++)
+                ShiftColumnDownUncheckedReuseArray(surface, null, x, 0, count, amount, false);
     }
 
     /// <summary>

--- a/Tests/SadConsole.Tests/CellSurface.Editor.ShiftConsole.cs
+++ b/Tests/SadConsole.Tests/CellSurface.Editor.ShiftConsole.cs
@@ -251,6 +251,9 @@ public partial class CellSurface
             Mirror = Mirror.None
         };
 
+        Assert.AreEqual(Math.Abs(shiftAmount), shiftAmount > 0 ? surface.TimesShiftedDown : surface.TimesShiftedUp);
+        Assert.AreEqual(0, shiftAmount > 0 ? surface.TimesShiftedUp : surface.TimesShiftedDown);
+
         foreach (var (x, y) in surface.Positions())
         {
             int oldY = y - shiftAmount;
@@ -273,6 +276,9 @@ public partial class CellSurface
             Decorators = Array.Empty<CellDecorator>(),
             Mirror = Mirror.None
         };
+
+        Assert.AreEqual(Math.Abs(shiftAmount), shiftAmount > 0 ? surface.TimesShiftedRight : surface.TimesShiftedLeft);
+        Assert.AreEqual(0, shiftAmount > 0 ? surface.TimesShiftedLeft : surface.TimesShiftedRight);
 
         foreach (var (x, y) in surface.Positions())
         {


### PR DESCRIPTION
# Overview
This is an attempt to optimize the `ShiftLeft`, `ShiftRight`, `ShiftUp`, and `ShiftDown` methods by using some of the same concepts created in the `ShiftRow` and `ShiftColumn` methods.

The primary focus is to improve performance by decreasing allocation, particularly during wrapping shifts.  Consider a vertical shift (up or down), with an amount > 0, with `wrap` set to `true`. The original implementation allocates a `List<Tuple<ColoredGlyph, int>>` with a capacity equal to `surface.Width * amount`; then throughout the process allocates `surface.Width * amount` of `Tuples` (a reference type), `surface.Width * amount` ColoredGlyphs (also a reference type) and a corresponding number of integers.

The new implementation aims to reduce the GCed allocation and do the minimal amount of work by bounding high values to equivalent values mathematically; in the case above, it will allocate a maximum of `surface.Height / 2` `ColoredGlyphAppearance` objects (as a single array of value types).

# Changes
There should be no API changes here; although several existing functions were rewritten and re-used code pulled out into private helper functions.  The only intended differences are performance related (detailed below).

## Benchmarks
This PR contains some performance tests that were used to benchmark the shifting code.  The following tables outline the original implementation and newer implementation:

### Original Implementation
|                  Method | Size |  Wrap |          Mean |         Error |        StdDev |
|------------------------ |----- |------ |--------------:|--------------:|--------------:|
|              ShiftUpOne |   10 | False |      1.531 us |     0.0178 us |     0.0166 us |
|             ShiftUpHalf |   10 | False |      1.847 us |     0.0082 us |     0.0064 us |
|   ShiftUpHeightMinusOne |   10 | False |      2.366 us |     0.0398 us |     0.0372 us |
|            ShiftDownOne |   10 | False |      1.425 us |     0.0096 us |     0.0089 us |
|           ShiftDownHalf |   10 | False |      1.825 us |     0.0111 us |     0.0098 us |
| ShiftDownHeightMinusOne |   10 | False |      2.147 us |     0.0056 us |     0.0044 us |
|           ShiftRightOne |   10 | False |      1.454 us |     0.0139 us |     0.0123 us |
|          ShiftRightHalf |   10 | False |      1.824 us |     0.0087 us |     0.0068 us |
| ShiftRightWidthMinusOne |   10 | False |      2.163 us |     0.0099 us |     0.0077 us |
|            ShiftLeftOne |   10 | False |      1.362 us |     0.0122 us |     0.0114 us |
|           ShiftLeftHalf |   10 | False |      1.847 us |     0.0179 us |     0.0168 us |
|  ShiftLeftWidthMinusOne |   10 | False |      2.207 us |     0.0214 us |     0.0190 us |
|              ShiftUpOne |   10 |  True |      1.794 us |     0.0140 us |     0.0124 us |
|             ShiftUpHalf |   10 |  True |      2.972 us |     0.0249 us |     0.0233 us |
|   ShiftUpHeightMinusOne |   10 |  True |      4.146 us |     0.0476 us |     0.0445 us |
|            ShiftDownOne |   10 |  True |      1.779 us |     0.0140 us |     0.0131 us |
|           ShiftDownHalf |   10 |  True |      3.016 us |     0.0525 us |     0.0491 us |
| ShiftDownHeightMinusOne |   10 |  True |      4.451 us |     0.0307 us |     0.0272 us |
|           ShiftRightOne |   10 |  True |      1.619 us |     0.0125 us |     0.0105 us |
|          ShiftRightHalf |   10 |  True |      2.884 us |     0.0144 us |     0.0120 us |
| ShiftRightWidthMinusOne |   10 |  True |      4.423 us |     0.0728 us |     0.0681 us |
|            ShiftLeftOne |   10 |  True |      1.631 us |     0.0126 us |     0.0112 us |
|           ShiftLeftHalf |   10 |  True |      2.980 us |     0.0415 us |     0.0388 us |
|  ShiftLeftWidthMinusOne |   10 |  True |      4.347 us |     0.0325 us |     0.0271 us |
|              ShiftUpOne |  100 | False |    131.550 us |     0.3768 us |     0.3340 us |
|             ShiftUpHalf |  100 | False |    178.126 us |     0.6840 us |     0.5712 us |
|   ShiftUpHeightMinusOne |  100 | False |    214.752 us |     2.9492 us |     2.7587 us |
|            ShiftDownOne |  100 | False |    125.431 us |     0.2648 us |     0.2067 us |
|           ShiftDownHalf |  100 | False |    185.630 us |     1.3655 us |     1.2105 us |
| ShiftDownHeightMinusOne |  100 | False |    215.819 us |     1.9832 us |     1.8551 us |
|           ShiftRightOne |  100 | False |    134.688 us |     0.9817 us |     0.7664 us |
|          ShiftRightHalf |  100 | False |    190.579 us |     1.2161 us |     1.0781 us |
| ShiftRightWidthMinusOne |  100 | False |    224.712 us |     2.1441 us |     1.9007 us |
|            ShiftLeftOne |  100 | False |    126.341 us |     0.8138 us |     0.7214 us |
|           ShiftLeftHalf |  100 | False |    187.722 us |     1.5568 us |     1.3000 us |
|  ShiftLeftWidthMinusOne |  100 | False |    229.621 us |     2.3406 us |     2.1894 us |
|              ShiftUpOne |  100 |  True |    123.284 us |     0.4916 us |     0.4358 us |
|             ShiftUpHalf |  100 |  True |    309.041 us |     3.5003 us |     3.1029 us |
|   ShiftUpHeightMinusOne |  100 |  True |    521.818 us |     5.2109 us |     4.8743 us |
|            ShiftDownOne |  100 |  True |    123.736 us |     0.3542 us |     0.3140 us |
|           ShiftDownHalf |  100 |  True |    296.640 us |     1.9920 us |     1.7659 us |
| ShiftDownHeightMinusOne |  100 |  True |    526.311 us |     4.0812 us |     3.8176 us |
|           ShiftRightOne |  100 |  True |    131.462 us |     1.1313 us |     1.0029 us |
|          ShiftRightHalf |  100 |  True |    343.972 us |     3.1730 us |     2.9680 us |
| ShiftRightWidthMinusOne |  100 |  True |    583.303 us |     3.8434 us |     3.4071 us |
|            ShiftLeftOne |  100 |  True |    129.606 us |     0.8081 us |     0.6748 us |
|           ShiftLeftHalf |  100 |  True |    342.220 us |     2.7252 us |     2.2757 us |
|  ShiftLeftWidthMinusOne |  100 |  True |    619.101 us |    10.0510 us |     8.9099 us |
|              ShiftUpOne |  500 | False |  3,334.107 us |    11.6424 us |     9.0897 us |
|             ShiftUpHalf |  500 | False |  4,667.861 us |    64.4332 us |    60.2709 us |
|   ShiftUpHeightMinusOne |  500 | False |  5,325.621 us |    74.4865 us |    69.6748 us |
|            ShiftDownOne |  500 | False |  3,327.716 us |    28.6303 us |    26.7808 us |
|           ShiftDownHalf |  500 | False |  4,767.544 us |    30.0082 us |    26.6015 us |
| ShiftDownHeightMinusOne |  500 | False |  5,541.616 us |    16.2184 us |    12.6622 us |
|           ShiftRightOne |  500 | False |  5,922.701 us |   106.2793 us |    99.4137 us |
|          ShiftRightHalf |  500 | False |  9,204.908 us |   132.4925 us |   117.4512 us |
| ShiftRightWidthMinusOne |  500 | False |  8,284.372 us |   161.7561 us |   186.2785 us |
|            ShiftLeftOne |  500 | False |  4,974.303 us |    91.4966 us |    85.5860 us |
|           ShiftLeftHalf |  500 | False |  8,680.707 us |   171.9315 us |   176.5610 us |
|  ShiftLeftWidthMinusOne |  500 | False |  8,206.786 us |   153.4082 us |   143.4982 us |
|              ShiftUpOne |  500 |  True |  3,402.195 us |    29.0272 us |    25.7318 us |
|             ShiftUpHalf |  500 |  True | 28,190.067 us |   509.9356 us |   452.0446 us |
|   ShiftUpHeightMinusOne |  500 |  True | 52,452.582 us | 1,048.2959 us | 1,207.2191 us |
|            ShiftDownOne |  500 |  True |  3,496.406 us |    25.9176 us |    24.2433 us |
|           ShiftDownHalf |  500 |  True | 28,489.453 us |   550.1403 us |   654.9029 us |
| ShiftDownHeightMinusOne |  500 |  True | 53,608.090 us | 1,069.4987 us | 2,414.0368 us |
|           ShiftRightOne |  500 |  True |  5,927.489 us |    53.4019 us |    47.3394 us |
|          ShiftRightHalf |  500 |  True | 36,613.235 us |   731.7768 us |   976.9011 us |
| ShiftRightWidthMinusOne |  500 |  True | 61,586.113 us | 1,227.0313 us | 2,181.0468 us |
|            ShiftLeftOne |  500 |  True |  4,997.926 us |    50.1908 us |    44.4929 us |
|           ShiftLeftHalf |  500 |  True | 35,024.829 us |   691.5457 us |   739.9462 us |
|  ShiftLeftWidthMinusOne |  500 |  True | 61,795.516 us | 1,221.7686 us | 2,577.1247 us |

### This PRs  Implementation
|                  Method | Size |  Wrap |         Mean |      Error |     StdDev |
|------------------------ |----- |------ |-------------:|-----------:|-----------:|
|              ShiftUpOne |   10 | False |     1.249 us |  0.0025 us |  0.0023 us |
|             ShiftUpHalf |   10 | False |     1.652 us |  0.0067 us |  0.0056 us |
|   ShiftUpHeightMinusOne |   10 | False |     2.018 us |  0.0067 us |  0.0056 us |
|            ShiftDownOne |   10 | False |     1.246 us |  0.0232 us |  0.0205 us |
|           ShiftDownHalf |   10 | False |     1.687 us |  0.0092 us |  0.0086 us |
| ShiftDownHeightMinusOne |   10 | False |     2.077 us |  0.0121 us |  0.0108 us |
|           ShiftRightOne |   10 | False |     1.242 us |  0.0122 us |  0.0108 us |
|          ShiftRightHalf |   10 | False |     1.668 us |  0.0119 us |  0.0111 us |
| ShiftRightWidthMinusOne |   10 | False |     2.134 us |  0.0250 us |  0.0222 us |
|            ShiftLeftOne |   10 | False |     1.179 us |  0.0099 us |  0.0088 us |
|           ShiftLeftHalf |   10 | False |     1.639 us |  0.0028 us |  0.0025 us |
|  ShiftLeftWidthMinusOne |   10 | False |     2.157 us |  0.0072 us |  0.0064 us |
|              ShiftUpOne |   10 |  True |     1.172 us |  0.0008 us |  0.0007 us |
|             ShiftUpHalf |   10 |  True |     1.309 us |  0.0030 us |  0.0024 us |
|   ShiftUpHeightMinusOne |   10 |  True |     1.230 us |  0.0037 us |  0.0029 us |
|            ShiftDownOne |   10 |  True |     1.230 us |  0.0030 us |  0.0025 us |
|           ShiftDownHalf |   10 |  True |     1.280 us |  0.0083 us |  0.0070 us |
| ShiftDownHeightMinusOne |   10 |  True |     1.179 us |  0.0091 us |  0.0085 us |
|           ShiftRightOne |   10 |  True |     1.170 us |  0.0034 us |  0.0030 us |
|          ShiftRightHalf |   10 |  True |     1.296 us |  0.0048 us |  0.0040 us |
| ShiftRightWidthMinusOne |   10 |  True |     1.215 us |  0.0061 us |  0.0054 us |
|            ShiftLeftOne |   10 |  True |     1.220 us |  0.0032 us |  0.0028 us |
|           ShiftLeftHalf |   10 |  True |     1.309 us |  0.0095 us |  0.0079 us |
|  ShiftLeftWidthMinusOne |   10 |  True |     1.161 us |  0.0033 us |  0.0026 us |
|              ShiftUpOne |  100 | False |    95.534 us |  0.6137 us |  0.5741 us |
|             ShiftUpHalf |  100 | False |   156.039 us |  0.6716 us |  0.5953 us |
|   ShiftUpHeightMinusOne |  100 | False |   211.096 us |  1.0549 us |  0.9868 us |
|            ShiftDownOne |  100 | False |    98.699 us |  0.4753 us |  0.3969 us |
|           ShiftDownHalf |  100 | False |   155.606 us |  2.1478 us |  2.0091 us |
| ShiftDownHeightMinusOne |  100 | False |   207.114 us |  1.2789 us |  1.1963 us |
|           ShiftRightOne |  100 | False |    92.835 us |  0.4717 us |  0.4412 us |
|          ShiftRightHalf |  100 | False |   154.360 us |  1.8700 us |  1.7492 us |
| ShiftRightWidthMinusOne |  100 | False |   209.236 us |  0.8660 us |  0.7677 us |
|            ShiftLeftOne |  100 | False |    97.027 us |  0.6156 us |  0.5758 us |
|           ShiftLeftHalf |  100 | False |   153.770 us |  0.6678 us |  0.5920 us |
|  ShiftLeftWidthMinusOne |  100 | False |   217.151 us |  1.4655 us |  1.2991 us |
|              ShiftUpOne |  100 |  True |   101.117 us |  1.0670 us |  0.9981 us |
|             ShiftUpHalf |  100 |  True |   125.409 us |  0.9290 us |  0.8235 us |
|   ShiftUpHeightMinusOne |  100 |  True |   102.076 us |  0.4770 us |  0.4228 us |
|            ShiftDownOne |  100 |  True |   101.513 us |  0.4319 us |  0.3607 us |
|           ShiftDownHalf |  100 |  True |   126.098 us |  0.1862 us |  0.1650 us |
| ShiftDownHeightMinusOne |  100 |  True |    99.912 us |  0.5376 us |  0.4766 us |
|           ShiftRightOne |  100 |  True |    96.873 us |  0.4204 us |  0.3510 us |
|          ShiftRightHalf |  100 |  True |   109.320 us |  0.5063 us |  0.4228 us |
| ShiftRightWidthMinusOne |  100 |  True |    99.141 us |  0.4518 us |  0.4226 us |
|            ShiftLeftOne |  100 |  True |    89.100 us |  0.4043 us |  0.3157 us |
|           ShiftLeftHalf |  100 |  True |   113.760 us |  0.6965 us |  0.6515 us |
|  ShiftLeftWidthMinusOne |  100 |  True |    96.900 us |  0.4067 us |  0.3396 us |
|              ShiftUpOne |  500 | False | 5,852.244 us | 22.4574 us | 21.0067 us |
|             ShiftUpHalf |  500 | False | 6,087.483 us | 69.1136 us | 64.6489 us |
|   ShiftUpHeightMinusOne |  500 | False | 7,693.614 us | 60.7260 us | 56.8031 us |
|            ShiftDownOne |  500 | False | 4,191.404 us | 61.1508 us | 51.0637 us |
|           ShiftDownHalf |  500 | False | 5,447.670 us | 83.5001 us | 74.0207 us |
| ShiftDownHeightMinusOne |  500 | False | 7,128.776 us | 26.7821 us | 22.3642 us |
|           ShiftRightOne |  500 | False | 2,661.873 us | 17.6307 us | 13.7649 us |
|          ShiftRightHalf |  500 | False | 4,699.689 us | 46.3911 us | 43.3942 us |
| ShiftRightWidthMinusOne |  500 | False | 5,682.952 us | 52.0185 us | 48.6581 us |
|            ShiftLeftOne |  500 | False | 2,512.795 us |  8.3853 us |  7.4333 us |
|           ShiftLeftHalf |  500 | False | 4,079.716 us | 63.8964 us | 59.7687 us |
|  ShiftLeftWidthMinusOne |  500 | False | 5,775.020 us | 60.9182 us | 56.9829 us |
|              ShiftUpOne |  500 |  True | 5,853.021 us | 36.8786 us | 32.6919 us |
|             ShiftUpHalf |  500 |  True | 6,736.610 us | 42.3207 us | 37.5162 us |
|   ShiftUpHeightMinusOne |  500 |  True | 4,121.226 us | 37.6044 us | 31.4014 us |
|            ShiftDownOne |  500 |  True | 4,149.526 us | 68.6416 us | 60.8490 us |
|           ShiftDownHalf |  500 |  True | 5,510.177 us | 22.7280 us | 20.1478 us |
| ShiftDownHeightMinusOne |  500 |  True | 5,943.485 us | 47.1807 us | 41.8245 us |
|           ShiftRightOne |  500 |  True | 3,198.337 us | 46.3236 us | 43.3311 us |
|          ShiftRightHalf |  500 |  True | 3,609.826 us | 60.0357 us | 56.1575 us |
| ShiftRightWidthMinusOne |  500 |  True | 2,205.016 us | 17.3590 us | 16.2377 us |
|            ShiftLeftOne |  500 |  True | 2,173.492 us | 30.2281 us | 26.7964 us |
|           ShiftLeftHalf |  500 |  True | 2,909.079 us | 18.8887 us | 15.7729 us |
|  ShiftLeftWidthMinusOne |  500 |  True | 3,192.637 us | 42.9167 us | 40.1443 us |


The new implementation is, in most cases, equivalent or faster; upwards of 95% faster in some of the extreme cases.  There are, however, some anomalies particularly in the 500x500 console size section, where on small shift amounts in vertical directions the new implementation is around 2000us slower.  I believe these are due to cache misses; the new implementation does vertical shifts by shifting each column in sequence, and column's values are not next to each other in memory.

It may be possible to mitigate these, however as far as I can tell the new implementation is, in the smaller cases, pretty much universally better as-is, and yields extreme benefits on larger shifts of larger consoles.