### PR TITLE
Fixed small off-by-one error

### DIFF
--- a/SadConsole.Extended/Entities/Manager.cs
+++ b/SadConsole.Extended/Entities/Manager.cs
@@ -278,7 +278,7 @@ namespace SadConsole.Entities
                 var entities = _entityByPosition[entity.Position];
                 var newList = new Entity[entities.Length];
                 entities.CopyTo(newList, 0);
-                newList[newList.Length] = entity;
+                newList[newList.Length-1] = entity;
                 _entityByPosition[entity.Position] = newList;
             }
             else


### PR DESCRIPTION
Fixed a small 'off-by-one' error in Sadconsole.Extended. Which caused an array 'out of bound' exception, when two entities shared the same position in the Manager.

PS. Can see the Manager has been overhauled in the developer branch, so please disregard if no longer relevant.  

