### PR TITLE
Bugfix: CellSurface resize from bigger height to smaller height with clear results in index out of bounds exception

### DIFF
--- a/SadConsole/CellSurface.cs
+++ b/SadConsole/CellSurface.cs
@@ -364,7 +364,7 @@ public class CellSurface : ICellSurface, ICellSurfaceResize, ICellSurfaceSettabl
                 // If clear set, clear the old cells
                 if (clear)
                 {
-                    for (int i = 0; i < Cells.Length; i++)
+                    for (int i = 0; i < newCells.Length; i++)
                         CellClear(Surface, newCells[i]);
                 }
             }

--- a/Tests/SadConsole.Tests/CellSurface.Resize.cs
+++ b/Tests/SadConsole.Tests/CellSurface.Resize.cs
@@ -371,7 +371,7 @@ namespace SadConsole.Tests
         [TestMethod]
         public void Resize_BiggerHeight_To_SmallerHeight_Clear_NoException()
         {
-            // This test only does bigger resize
+            // This test does only big height to small height with clear
             new SadConsole.Tests.BasicGameHost();
 
             int width = 20;
@@ -393,7 +393,7 @@ namespace SadConsole.Tests
         [TestMethod]
         public void Resize_SmallerHeight_To_BiggerHeight_Clear_NoException()
         {
-            // This test only does bigger resize
+            // This test does only small height to big height with clear
             new SadConsole.Tests.BasicGameHost();
 
             int width = 20;
@@ -415,7 +415,7 @@ namespace SadConsole.Tests
         [TestMethod]
         public void Resize_BiggerWidth_To_SmallerWidth_Clear_NoException()
         {
-            // This test only does bigger resize
+            // This test does only big width to small width with clear
             new SadConsole.Tests.BasicGameHost();
 
             int width = 25;
@@ -437,7 +437,7 @@ namespace SadConsole.Tests
         [TestMethod]
         public void Resize_SmallerWidth_To_BiggerWidth_Clear_NoException()
         {
-            // This test only does bigger resize
+            // This test does only small width to big width with clear
             new SadConsole.Tests.BasicGameHost();
 
             int width = 20;

--- a/Tests/SadConsole.Tests/CellSurface.Resize.cs
+++ b/Tests/SadConsole.Tests/CellSurface.Resize.cs
@@ -367,5 +367,93 @@ namespace SadConsole.Tests
             Assert.IsTrue(surface1[point2].Matches(clearCell));
             Assert.IsTrue(surface1[point3].Matches(clearCell));
         }
+
+        [TestMethod]
+        public void Resize_BiggerHeight_To_SmallerHeight_Clear_NoException()
+        {
+            // This test only does bigger resize
+            new SadConsole.Tests.BasicGameHost();
+
+            int width = 20;
+            int height = 25;
+
+            var surface1 = new SadConsole.CellSurface(width, height);
+            surface1.FillWithRandomGarbage(255);
+
+            int newWidth = width;
+            int newHeight = height - 5;
+
+            // Should not throw index outside of bounds
+            surface1.Resize(newWidth, newHeight, newWidth, newHeight, true);
+
+            Assert.AreEqual(newWidth, surface1.Width);
+            Assert.AreEqual(newHeight, surface1.Height);
+        }
+
+        [TestMethod]
+        public void Resize_SmallerHeight_To_BiggerHeight_Clear_NoException()
+        {
+            // This test only does bigger resize
+            new SadConsole.Tests.BasicGameHost();
+
+            int width = 20;
+            int height = 20;
+
+            var surface1 = new SadConsole.CellSurface(width, height);
+            surface1.FillWithRandomGarbage(255);
+
+            int newWidth = width;
+            int newHeight = height + 5;
+
+            // Should not throw index outside of bounds
+            surface1.Resize(newWidth, newHeight, newWidth, newHeight, true);
+
+            Assert.AreEqual(newWidth, surface1.Width);
+            Assert.AreEqual(newHeight, surface1.Height);
+        }
+
+        [TestMethod]
+        public void Resize_BiggerWidth_To_SmallerWidth_Clear_NoException()
+        {
+            // This test only does bigger resize
+            new SadConsole.Tests.BasicGameHost();
+
+            int width = 25;
+            int height = 20;
+
+            var surface1 = new SadConsole.CellSurface(width, height);
+            surface1.FillWithRandomGarbage(255);
+
+            int newWidth = width - 5;
+            int newHeight = height;
+
+            // Should not throw index outside of bounds
+            surface1.Resize(newWidth, newHeight, newWidth, newHeight, true);
+
+            Assert.AreEqual(newWidth, surface1.Width);
+            Assert.AreEqual(newHeight, surface1.Height);
+        }
+
+        [TestMethod]
+        public void Resize_SmallerWidth_To_BiggerWidth_Clear_NoException()
+        {
+            // This test only does bigger resize
+            new SadConsole.Tests.BasicGameHost();
+
+            int width = 20;
+            int height = 20;
+
+            var surface1 = new SadConsole.CellSurface(width, height);
+            surface1.FillWithRandomGarbage(255);
+
+            int newWidth = width + 5;
+            int newHeight = height;
+
+            // Should not throw index outside of bounds
+            surface1.Resize(newWidth, newHeight, newWidth, newHeight, true);
+
+            Assert.AreEqual(newWidth, surface1.Width);
+            Assert.AreEqual(newHeight, surface1.Height);
+        }
     }
 }


### PR DESCRIPTION
Added also few extra tests to cover the other scenarios.